### PR TITLE
docs: add PyPI README for parser-core and parser-free packages

### DIFF
--- a/packages/parser-core/README.md
+++ b/packages/parser-core/README.md
@@ -1,0 +1,51 @@
+# bankstatements-core
+
+[![CI](https://github.com/longieirl/bankstatementprocessor/actions/workflows/ci.yml/badge.svg)](https://github.com/longieirl/bankstatementprocessor/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/bankstatements-core)](https://pypi.org/project/bankstatements-core/)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+Core PDF bank statement parsing library — PDF extraction, services, and templates.
+
+Used as the foundation for [`bankstatements-free`](https://pypi.org/project/bankstatements-free/) and the premium distribution.
+
+---
+
+## Installation
+
+```bash
+pip install bankstatements-core
+```
+
+## Features
+
+- PDF extraction with configurable table boundaries
+- Template-based statement detection (AIB Ireland, Revolut, and more)
+- CSV, JSON, and Excel export
+- Batch processing with recursive directory scanning
+- SHA-256 duplicate detection
+- Transaction type classification (purchase, payment, refund, fee, transfer)
+- Monthly summaries and expense analysis
+- IBAN extraction and grouping
+- GDPR-compliant local processing — no data leaves your machine
+
+## Supported Banks
+
+| Bank | Template |
+|---|---|
+| AIB Ireland | `aib_ireland.json` |
+| Revolut | `revolut.json` |
+| Generic fallback | `default.json` |
+
+## Quick Start
+
+```python
+from bankstatements_core.services.processor import StatementProcessor
+
+processor = StatementProcessor(input_dir="./input", output_dir="./output")
+results = processor.process()
+```
+
+## Documentation
+
+Full documentation and source: [github.com/longieirl/bankstatementprocessor](https://github.com/longieirl/bankstatementprocessor)

--- a/packages/parser-free/README.md
+++ b/packages/parser-free/README.md
@@ -1,0 +1,51 @@
+# bankstatements-free
+
+[![CI](https://github.com/longieirl/bankstatementprocessor/actions/workflows/ci.yml/badge.svg)](https://github.com/longieirl/bankstatementprocessor/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/bankstatements-free)](https://pypi.org/project/bankstatements-free/)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+Free-tier CLI for parsing PDF bank statements into structured CSV, JSON, and Excel — locally, with no cloud services.
+
+Built on [`bankstatements-core`](https://pypi.org/project/bankstatements-core/).
+
+---
+
+## Installation
+
+```bash
+pip install bankstatements-free
+```
+
+## Quick Start
+
+```bash
+# Place PDF statements in an input directory
+bankstatements --input ./input --output ./output
+
+# Choose output formats
+bankstatements --input ./input --output ./output --output-formats csv,json,excel
+```
+
+## Features
+
+- Parse PDF bank statements from AIB Ireland, Revolut, and more
+- Export to CSV, JSON, and Excel
+- Batch processing with recursive directory scanning
+- SHA-256 duplicate detection
+- Transaction type classification (purchase, payment, refund, fee, transfer)
+- Monthly summaries and expense analysis
+- IBAN extraction and grouping
+- GDPR-compliant local processing — no data leaves your machine
+
+## Supported Banks
+
+| Bank | Template |
+|---|---|
+| AIB Ireland | `aib_ireland.json` |
+| Revolut | `revolut.json` |
+| Generic fallback | `default.json` |
+
+## Documentation
+
+Full documentation and source: [github.com/longieirl/bankstatementprocessor](https://github.com/longieirl/bankstatementprocessor)


### PR DESCRIPTION
## Summary

- Add `packages/parser-core/README.md` — displayed on PyPI for `bankstatements-core`
- Add `packages/parser-free/README.md` — displayed on PyPI for `bankstatements-free`

Both packages referenced `readme = "README.md"` in `pyproject.toml` but the files were missing, causing PyPI to show "The author of this package has not provided a project description".

## Test plan

- [ ] After next release, verify PyPI pages for both packages show the description