### PR TITLE
fix: use files input for codecov-action (deprecates file)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       if: matrix.python-version == '3.12'
       uses: codecov/codecov-action@v5
       with:
-        file: packages/parser-core/coverage.xml
+        files: packages/parser-core/coverage.xml
         flags: parser-core
         fail_ci_if_error: false
 


### PR DESCRIPTION
Fixes deprecation warning — `file` input is deprecated in `codecov/codecov-action@v5`, replaced by `files`.