### PR TITLE
feat: decompose PDFTableExtractor into focused collaborators (RFC #18)

### DIFF
--- a/packages/parser-core/src/bankstatements_core/extraction/__init__.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/__init__.py
@@ -10,18 +10,28 @@ from bankstatements_core.extraction.column_identifier import (
     ColumnType,
     ColumnTypeIdentifier,
 )
+from bankstatements_core.extraction.page_header_analyser import PageHeaderAnalyser
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
+from bankstatements_core.extraction.row_builder import RowBuilder
 from bankstatements_core.extraction.row_classifiers import (
     RowClassifier,
     create_row_classifier_chain,
+)
+from bankstatements_core.extraction.row_post_processor import (
+    RowPostProcessor,
+    extract_filename_date,
 )
 
 __all__ = [
     "BoundaryDetectionResult",
     "ColumnType",
     "ColumnTypeIdentifier",
+    "PageHeaderAnalyser",
     "PDFTableExtractor",
+    "RowBuilder",
     "RowClassifier",
+    "RowPostProcessor",
     "TableBoundaryDetector",
     "create_row_classifier_chain",
+    "extract_filename_date",
 ]

--- a/packages/parser-core/src/bankstatements_core/extraction/page_header_analyser.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/page_header_analyser.py
@@ -1,0 +1,84 @@
+"""Page header analysis for PDF bank statements.
+
+Encapsulates logic that inspects the page area before the transaction table:
+credit card detection and IBAN extraction.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bankstatements_core.extraction.iban_extractor import IBANExtractor
+
+logger = logging.getLogger(__name__)
+
+_CREDIT_CARD_PATTERNS = [
+    r"card\s+number",
+    r"credit\s+limit",
+    r"credit\s+card",
+    r"\bvisa\b",
+    r"\bmastercard\b",
+]
+
+_IBAN_HEADER_Y = 350
+
+
+class PageHeaderAnalyser:
+    """Inspects the page header area for credit card indicators and IBAN."""
+
+    def __init__(self, iban_extractor: "IBANExtractor") -> None:
+        self._iban_extractor = iban_extractor
+
+    def is_credit_card_statement(self, page: Any, table_top_y: int) -> bool:
+        """Return True if the page header contains credit card indicators.
+
+        Args:
+            page: pdfplumber page object
+            table_top_y: Top Y boundary of the transaction table; header is above this
+
+        Returns:
+            True if credit card statement detected, False otherwise
+        """
+        try:
+            header_area = page.crop((0, 0, page.width, table_top_y))
+            header_text = header_area.extract_text()
+            if header_text:
+                for pattern in _CREDIT_CARD_PATTERNS:
+                    if re.search(pattern, header_text, re.IGNORECASE):
+                        logger.debug(
+                            f"Credit card indicator found in header: pattern '{pattern}' matched"
+                        )
+                        return True
+        except (AttributeError, ValueError, TypeError) as e:
+            logger.warning(f"Error checking for credit card statement: {e}")
+        return False
+
+    def extract_iban(self, page: Any) -> str | None:
+        """Extract account IBAN from the page header area (y < 350).
+
+        Args:
+            page: pdfplumber page object
+
+        Returns:
+            IBAN string if found, None otherwise
+        """
+        try:
+            header_area = page.crop((0, 0, page.width, _IBAN_HEADER_Y))
+            header_text = header_area.extract_text()
+            if header_text:
+                iban = self._iban_extractor.extract_iban(header_text)
+                if iban:
+                    return iban
+
+            header_words = header_area.extract_words(use_text_flow=True)
+            if header_words:
+                iban = self._iban_extractor.extract_iban_from_pdf_words(header_words)
+                if iban:
+                    return iban
+        except (AttributeError, ValueError, KeyError, TypeError) as e:
+            logger.warning(f"Error extracting IBAN from page: {e}")
+
+        return None

--- a/packages/parser-core/src/bankstatements_core/extraction/pdf_extractor.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/pdf_extractor.py
@@ -7,17 +7,20 @@ PDF bank statements with proper separation of concerns.
 from __future__ import annotations
 
 import logging
-import re
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from bankstatements_core.domain.protocols.pdf_reader import IPDFReader
 
-from bankstatements_core.extraction.column_identifier import ColumnTypeIdentifier
 from bankstatements_core.extraction.iban_extractor import IBANExtractor
+from bankstatements_core.extraction.page_header_analyser import PageHeaderAnalyser
+from bankstatements_core.extraction.row_builder import RowBuilder
 from bankstatements_core.extraction.row_classifiers import create_row_classifier_chain
+from bankstatements_core.extraction.row_post_processor import (
+    RowPostProcessor,
+    extract_filename_date,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +29,10 @@ class PDFTableExtractor:
     """
     Orchestrates extraction of table data from PDF files.
 
-    Handles page iteration, boundary detection, word grouping, row extraction,
-    continuation line merging, and date propagation.
+    Delegates to focused collaborators:
+    - PageHeaderAnalyser: credit card detection and IBAN extraction
+    - RowBuilder: word-to-row conversion and classification filtering
+    - RowPostProcessor: date propagation and metadata tagging
     """
 
     def __init__(
@@ -43,29 +48,20 @@ class PDFTableExtractor:
         extraction_config: "Any | None" = None,
         template: "Any | None" = None,
     ):
-        """
-        Initialize PDF table extractor.
-
-        Args:
-            columns: Column definitions mapping names to (x_min, x_max) boundaries
-            table_top_y: Top Y coordinate for table extraction (default for all pages)
-            table_bottom_y: Bottom Y coordinate for table extraction (default for all pages)
-            enable_dynamic_boundary: Whether to use dynamic table end detection
-            enable_page_validation: Whether to validate page structure (default: True)
-            enable_header_check: Whether to check for table headers (default: True)
-            header_check_top_y: Y-coordinate to start header search (None = auto-calculate)
-            pdf_reader: Optional PDF reader for dependency injection (default: use pdfplumber adapter)
-            extraction_config: Optional TemplateExtractionConfig for per-page boundary support
-            template: Optional BankTemplate for document type information
-        """
         self.columns = columns
         self.table_top_y = table_top_y
         self.table_bottom_y = table_bottom_y
-        self.iban_extractor = IBANExtractor()
         self.enable_dynamic_boundary = enable_dynamic_boundary
-        self._row_classifier = create_row_classifier_chain()
+        self.page_validation_enabled = enable_page_validation
+        self.header_check_enabled = enable_header_check
+        self.header_check_top_y = header_check_top_y
+        self.extraction_config = extraction_config
+        self.template = template
 
-        # Inject PDF reader or use default pdfplumber adapter
+        self._row_classifier = create_row_classifier_chain()
+        self._row_builder = RowBuilder(columns, self._row_classifier)
+        self._header_analyser = PageHeaderAnalyser(IBANExtractor())
+
         if pdf_reader is None:
             from bankstatements_core.adapters.pdfplumber_adapter import (
                 PDFPlumberReaderAdapter,
@@ -75,24 +71,8 @@ class PDFTableExtractor:
         else:
             self._pdf_reader = pdf_reader
 
-        # Page validation setting (enabled by default to ensure table presence)
-        self.page_validation_enabled = enable_page_validation
-
-        # Header check setting
-        self.header_check_enabled = enable_header_check
-
-        # Header check area (template-specific or auto-calculated)
-        self.header_check_top_y = header_check_top_y
-
-        # Store extraction config for per-page boundary support (NEW)
-        self.extraction_config = extraction_config
-
-        # Store template for document type information (NEW)
-        self.template = template
-
     def extract(self, pdf_path: Path) -> tuple[list[dict], int, str | None]:
-        """
-        Extract table data from PDF file.
+        """Extract table data from PDF file.
 
         Args:
             pdf_path: Path to the PDF file
@@ -101,60 +81,54 @@ class PDFTableExtractor:
             Tuple of (extracted rows, total page count, IBAN if found)
         """
         rows: list[dict] = []
-        filename = pdf_path.name
         current_date = ""
-        iban = None  # Will store the first IBAN found
+        iban = None
 
-        # Extract date from filename as fallback
-        filename_date = self._extract_filename_date(filename)
+        filename_date = extract_filename_date(pdf_path.name)
+        post_processor = RowPostProcessor(
+            columns=self.columns,
+            row_classifier=self._row_classifier,
+            template=self.template,
+            filename_date=filename_date,
+            filename=pdf_path.name,
+        )
 
         with self._pdf_reader.open(pdf_path) as pdf:
-            pages_processed = 0
-
             for page_num, page in enumerate(pdf.pages, 1):
-                # Check first page for credit card statement
-                if page_num == 1 and self._is_credit_card_statement(page):
+                if page_num == 1 and self._header_analyser.is_credit_card_statement(
+                    page, self.table_top_y
+                ):
                     logger.warning(
-                        f"Credit card statement detected in {filename}. "
+                        f"Credit card statement detected in {pdf_path.name}. "
                         f"Credit card statements are not currently supported. Skipping file."
                     )
-                    # Return empty results - this will skip the entire PDF
                     return [], len(pdf.pages), None
 
-                # Try to extract IBAN from first page if not found yet
                 if iban is None and page_num == 1:
-                    iban = self._extract_iban_from_page(page)
+                    iban = self._header_analyser.extract_iban(page)
                     if iban:
                         logger.info(
                             f"IBAN found on page {page_num}: {iban[:4]}****{iban[-4:]}"
                         )
 
                 page_rows = self._extract_page(page, page_num)
-
                 if page_rows is None:
-                    # Page was skipped (invalid structure or no headers)
                     continue
 
-                # Page validation passed
-                pages_processed += 1
                 logger.info(
                     f"Page {page_num}: Valid table structure found, "
                     f"processing {len(page_rows)} rows"
                 )
 
-                # Process rows and propagate dates
                 for row in page_rows:
-                    current_date = self._process_row(
-                        row, current_date, filename_date, filename
-                    )
-                    if row:  # Row may be None if filtered
+                    current_date = post_processor.process(row, current_date)
+                    if row:
                         rows.append(row)
 
             return rows, len(pdf.pages), iban
 
     def _extract_page(self, page: Any, page_num: int) -> list[dict] | None:
-        """
-        Extract rows from a single page.
+        """Extract rows from a single page.
 
         Args:
             page: pdfplumber page object
@@ -163,15 +137,12 @@ class PDFTableExtractor:
         Returns:
             List of extracted rows, or None if page should be skipped
         """
-        # Determine boundaries and extract words
         words = self._determine_boundaries_and_extract(page, page_num)
         if words is None:
-            return None  # Page skipped
+            return None
 
-        # Group words by Y position and build rows
-        page_rows = self._extract_rows_from_words(words)
+        page_rows = self._row_builder.build_rows(words)
 
-        # Validate page structure
         if self.page_validation_enabled:
             from bankstatements_core.pdf_table_extractor import validate_page_structure
 
@@ -182,18 +153,14 @@ class PDFTableExtractor:
                 )
                 return None
 
-        # Merge continuation lines
         from bankstatements_core.pdf_table_extractor import merge_continuation_lines
 
-        page_rows = merge_continuation_lines(page_rows, self.columns)
-
-        return page_rows
+        return merge_continuation_lines(page_rows, self.columns)
 
     def _determine_boundaries_and_extract(
         self, page: Any, page_num: int
     ) -> list[dict] | None:
-        """
-        Determine table boundaries and extract words (with per-page boundary support).
+        """Determine table boundaries and extract words (with per-page boundary support).
 
         Args:
             page: pdfplumber page object
@@ -202,39 +169,28 @@ class PDFTableExtractor:
         Returns:
             List of word dictionaries, or None if page should be skipped
         """
-        # Get page-specific boundaries if extraction_config is available (NEW)
         if self.extraction_config is not None:
             table_top_y = self.extraction_config.get_table_top_y(page_num)
             table_bottom_y = self.extraction_config.get_table_bottom_y(page_num)
             header_check_top_y = self.extraction_config.get_header_check_top_y(page_num)
         else:
-            # Fallback to instance defaults
             table_top_y = self.table_top_y
             table_bottom_y = self.table_bottom_y
             header_check_top_y = self.header_check_top_y
 
         if self.enable_dynamic_boundary:
-            # Extract all words initially for boundary detection
-            # Use table_bottom_y as upper limit to prevent extracting footer content
-            max_extraction_y = min(
-                table_bottom_y + 100, page.height
-            )  # Allow 100px margin for detection
+            max_extraction_y = min(table_bottom_y + 100, page.height)
             initial_area = page.crop((0, table_top_y, page.width, max_extraction_y))
             all_words = initial_area.extract_words(use_text_flow=True)
 
-            # Check for table headers in dynamic mode
             if self.header_check_enabled:
                 from bankstatements_core.pdf_table_extractor import detect_table_headers
 
-                # Use template-specific header check area or auto-calculate
-                if header_check_top_y is not None:
-                    # Template explicitly specifies where to look for headers
-                    header_top = header_check_top_y
-                else:
-                    # Auto-calculate: look 50px above table_top_y for headers
-                    header_top = max(0, table_top_y - 50)
-
-                # Extract header area for detection
+                header_top = (
+                    header_check_top_y
+                    if header_check_top_y is not None
+                    else max(0, table_top_y - 50)
+                )
                 header_area = page.crop((0, header_top, page.width, page.height))
                 header_words = header_area.extract_words(use_text_flow=True)
 
@@ -242,7 +198,6 @@ class PDFTableExtractor:
                     logger.info(f"Page {page_num}: No table headers detected, skipping")
                     return None
 
-            # Detect dynamic boundary
             from bankstatements_core.pdf_table_extractor import (
                 detect_table_end_boundary_smart,
             )
@@ -255,8 +210,6 @@ class PDFTableExtractor:
                 row_classifier=self._row_classifier,
             )
 
-            # Safety check: Cap dynamic boundary at static boundary to prevent over-extraction
-            # Dynamic detection should refine the boundary, not expand beyond static limits
             if dynamic_bottom_y > table_bottom_y:
                 logger.warning(
                     f"Page {page_num}: Dynamic boundary ({dynamic_bottom_y}) exceeds "
@@ -264,245 +217,26 @@ class PDFTableExtractor:
                 )
                 dynamic_bottom_y = table_bottom_y
 
-            # Extract with dynamic boundary
             table_area = page.crop((0, table_top_y, page.width, dynamic_bottom_y))
-            words = table_area.extract_words(use_text_flow=True)
-        else:
-            # Use static boundary
-            table_area = page.crop((0, table_top_y, page.width, table_bottom_y))
-            words = table_area.extract_words(use_text_flow=True)
+            return table_area.extract_words(use_text_flow=True)  # type: ignore[no-any-return]
 
-            # Check for table headers in static mode
-            if self.header_check_enabled:
-                from bankstatements_core.pdf_table_extractor import detect_table_headers
+        # Static boundary path
+        table_area = page.crop((0, table_top_y, page.width, table_bottom_y))
+        words = table_area.extract_words(use_text_flow=True)
 
-                # Use template-specific header check area or auto-calculate
-                if header_check_top_y is not None:
-                    # Template explicitly specifies where to look for headers
-                    header_top = header_check_top_y
-                else:
-                    # Auto-calculate: look 50px above table_top_y for headers
-                    header_top = max(0, table_top_y - 50)
+        if self.header_check_enabled:
+            from bankstatements_core.pdf_table_extractor import detect_table_headers
 
-                header_area = page.crop((0, header_top, page.width, table_bottom_y))
-                header_words = header_area.extract_words(use_text_flow=True)
+            header_top = (
+                header_check_top_y
+                if header_check_top_y is not None
+                else max(0, table_top_y - 50)
+            )
+            header_area = page.crop((0, header_top, page.width, table_bottom_y))
+            header_words = header_area.extract_words(use_text_flow=True)
 
-                if not detect_table_headers(header_words, self.columns):
-                    logger.info(f"Page {page_num}: No table headers detected, skipping")
-                    return None
+            if not detect_table_headers(header_words, self.columns):
+                logger.info(f"Page {page_num}: No table headers detected, skipping")
+                return None
 
         return words  # type: ignore[no-any-return]
-
-    def _extract_rows_from_words(self, words: list[dict]) -> list[dict]:
-        """
-        Group words by Y position and build row dictionaries.
-
-        Args:
-            words: List of word dictionaries from pdfplumber
-
-        Returns:
-            List of row dictionaries
-        """
-        # Group words by Y coordinate
-        lines: dict[float, list[dict]] = {}
-        for w in words:
-            y_key = round(w["top"], 0)
-            lines.setdefault(y_key, []).append(w)
-
-        page_rows = []
-        for _, line_words in sorted(lines.items()):
-            row = dict.fromkeys(self.columns, "")
-
-            # Assign words to columns based on X position
-            # Get list of column names to determine rightmost column
-            column_names = list(self.columns.keys())
-            rightmost_column = column_names[-1] if column_names else None
-
-            for w in line_words:
-                x0 = w["x0"]  # Left edge of word
-                # Right edge: real pdfplumber always provides x1, but for tests we estimate
-                # Using smaller multiplier (3) to avoid over-estimating word width
-                x1 = w.get("x1", x0 + max(len(w["text"]) * 3, 10))
-                text = w["text"]
-
-                for col, (xmin, xmax) in self.columns.items():
-                    # BOUNDARY CHECKING STRATEGY:
-                    # - For rightmost column (usually Balance): STRICT check (prevents footer bleed)
-                    # - For other columns: RELAXED check (just x0 within bounds)
-                    # This balances protection against footer text with flexibility for amounts
-                    if col == rightmost_column:
-                        # Strict: word must be FULLY contained
-                        if xmin <= x0 and x1 <= xmax:
-                            row[col] += text + " "
-                            break
-                    else:
-                        # Relaxed: word just needs to START within column
-                        if xmin <= x0 < xmax:
-                            row[col] += text + " "
-                            break
-
-            # Normalize and filter
-            row = {k: v.strip() for k, v in row.items()}
-
-            # Include transactions and continuation lines
-            if any(row.values()):
-                row_type = self._row_classifier.classify(row, self.columns)
-                if row_type in ["transaction", "continuation"]:
-                    page_rows.append(row)
-
-        return page_rows
-
-    def _process_row(
-        self,
-        row: dict,
-        current_date: str,
-        filename_date: str,
-        filename: str,
-    ) -> str:
-        """
-        Process a row: propagate dates, add filename, filter non-transactions.
-
-        Args:
-            row: Row dictionary to process (modified in-place)
-            current_date: Current date being tracked
-            filename_date: Date extracted from filename
-            filename: Source filename
-
-        Returns:
-            Updated current_date value
-        """
-        # Only process actual transactions after merging
-        if self._row_classifier.classify(row, self.columns) != "transaction":
-            return current_date
-
-        # Find date column
-        date_col = ColumnTypeIdentifier.find_first_column_of_type(self.columns, "date")
-
-        # Propagate dates
-        if date_col and row.get(date_col):
-            current_date = row[date_col]
-        elif date_col and (current_date or filename_date):
-            # Use last seen date or filename date
-            fallback_date = current_date or filename_date
-            row[date_col] = fallback_date
-            if not current_date:
-                current_date = fallback_date
-
-        # Tag with source filename
-        row["Filename"] = filename
-
-        # Add document type and template ID from template
-        if self.template:
-            row["document_type"] = self.template.document_type
-            row["template_id"] = self.template.id
-        else:
-            row["document_type"] = "bank_statement"  # Default fallback
-            row["template_id"] = None
-
-        return current_date
-
-    def _extract_filename_date(self, filename: str) -> str:
-        """
-        Extract date from filename (YYYYMMDD pattern).
-
-        Args:
-            filename: Filename to extract date from
-
-        Returns:
-            Formatted date string (e.g., "02 Feb 2025"), or empty string if no date
-        """
-        date_match = re.search(r"(\d{8})", filename)
-        if not date_match:
-            return ""
-
-        date_str = date_match.group(1)
-        try:
-            date_obj = datetime.strptime(date_str, "%Y%m%d")
-            return date_obj.strftime("%d %b %Y")
-        except ValueError:
-            return ""
-
-    def _is_credit_card_statement(self, page: Any) -> bool:
-        """
-        Check if a PDF page contains credit card statement indicators.
-
-        Credit card statements are not currently supported and should be skipped.
-        Checks for keywords like 'Card Number', 'Credit Limit', 'Credit Card',
-        'Visa', or 'Mastercard' in the HEADER area only (before transaction table).
-
-        Args:
-            page: pdfplumber page object
-
-        Returns:
-            True if credit card statement detected, False otherwise
-        """
-        try:
-            # Extract text from header area only (before transaction table starts)
-            # Use table_top_y to exclude transaction table area
-            header_area = page.crop((0, 0, page.width, self.table_top_y))
-            header_text = header_area.extract_text()
-
-            if header_text:
-                # Search for credit card indicators (case-insensitive)
-                # These patterns are strong indicators of a credit card statement
-                credit_card_patterns = [
-                    r"card\s+number",  # Card Number
-                    r"credit\s+limit",  # Credit Limit
-                    r"credit\s+card",  # Credit Card
-                    r"\bvisa\b",  # Visa (word boundary to avoid "advisa")
-                    r"\bmastercard\b",  # Mastercard
-                ]
-
-                for pattern in credit_card_patterns:
-                    if re.search(pattern, header_text, re.IGNORECASE):
-                        logger.debug(
-                            f"Credit card indicator found in header: pattern '{pattern}' matched"
-                        )
-                        return True
-            return False
-        except (AttributeError, ValueError, TypeError) as e:
-            # Expected errors: page object issues, regex errors, text extraction failures
-            logger.warning(f"Error checking for credit card statement: {e}")
-            return False
-        # Let unexpected errors bubble up
-
-    def _extract_iban_from_page(self, page: Any) -> str | None:
-        """
-        Extract IBAN from a PDF page header area.
-
-        Only extracts from the header/metadata section (before transaction table)
-        to avoid false positives from IBANs mentioned in transaction descriptions.
-
-        Args:
-            page: pdfplumber page object
-
-        Returns:
-            IBAN string if found, None otherwise
-        """
-        try:
-            # Extract text from header area only (before transaction table starts)
-            # This ensures we get the account IBAN, not IBANs from transaction descriptions
-            # Use a fixed generous header area (Y=350) to ensure IBAN is captured
-            # regardless of table_top_y setting
-            iban_header_y = 350
-            header_area = page.crop((0, 0, page.width, iban_header_y))
-            header_text = header_area.extract_text()
-
-            if header_text:
-                iban = self.iban_extractor.extract_iban(header_text)
-                if iban:
-                    return iban
-
-            # If not found in header text, try extracting from header words
-            header_words = header_area.extract_words(use_text_flow=True)
-            if header_words:
-                iban = self.iban_extractor.extract_iban_from_pdf_words(header_words)
-                if iban:
-                    return iban
-
-        except (AttributeError, ValueError, KeyError, TypeError) as e:
-            # Expected errors: page object issues, crop failures, extraction errors, type mismatches
-            logger.warning(f"Error extracting IBAN from page: {e}")
-        # Let unexpected errors bubble up
-
-        return None

--- a/packages/parser-core/src/bankstatements_core/extraction/row_builder.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/row_builder.py
@@ -1,0 +1,77 @@
+"""Word-to-row conversion and classification filtering.
+
+Encapsulates grouping PDF words by Y position, assigning them to columns,
+and filtering to only transaction/continuation rows.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bankstatements_core.extraction.row_classifiers import RowClassifier
+
+logger = logging.getLogger(__name__)
+
+
+class RowBuilder:
+    """Converts a flat list of PDF words into classified row dictionaries.
+
+    Boundary strategy:
+    - Rightmost column: STRICT check (word must be fully contained) to prevent
+      footer text bleeding into the balance column.
+    - All other columns: RELAXED check (word's left edge within bounds).
+    """
+
+    def __init__(
+        self,
+        columns: dict[str, tuple[int | float, int | float]],
+        row_classifier: "RowClassifier",
+    ) -> None:
+        self._columns = columns
+        self._row_classifier = row_classifier
+        self._column_names = list(columns.keys())
+        self._rightmost_column = self._column_names[-1] if self._column_names else None
+
+    def build_rows(self, words: list[dict]) -> list[dict]:
+        """Group words by Y position, assign to columns, return transaction/continuation rows.
+
+        Args:
+            words: List of word dictionaries from pdfplumber
+
+        Returns:
+            List of row dictionaries classified as 'transaction' or 'continuation'
+        """
+        lines: dict[float, list[dict]] = {}
+        for w in words:
+            y_key = round(w["top"], 0)
+            lines.setdefault(y_key, []).append(w)
+
+        page_rows = []
+        for _, line_words in sorted(lines.items()):
+            row = dict.fromkeys(self._columns, "")
+
+            for w in line_words:
+                x0 = w["x0"]
+                x1 = w.get("x1", x0 + max(len(w["text"]) * 3, 10))
+                text = w["text"]
+
+                for col, (xmin, xmax) in self._columns.items():
+                    if col == self._rightmost_column:
+                        if xmin <= x0 and x1 <= xmax:
+                            row[col] += text + " "
+                            break
+                    else:
+                        if xmin <= x0 < xmax:
+                            row[col] += text + " "
+                            break
+
+            row = {k: v.strip() for k, v in row.items()}
+
+            if any(row.values()):
+                row_type = self._row_classifier.classify(row, self._columns)
+                if row_type in ["transaction", "continuation"]:
+                    page_rows.append(row)
+
+        return page_rows

--- a/packages/parser-core/src/bankstatements_core/extraction/row_post_processor.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/row_post_processor.py
@@ -1,0 +1,92 @@
+"""Row post-processing: date propagation and metadata tagging.
+
+Encapsulates the per-row logic that runs after word-to-row conversion:
+filling in missing dates and stamping each row with filename/document_type/template_id.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from bankstatements_core.extraction.column_identifier import ColumnTypeIdentifier
+
+if TYPE_CHECKING:
+    from bankstatements_core.extraction.row_classifiers import RowClassifier
+    from bankstatements_core.templates.template_model import BankTemplate
+
+logger = logging.getLogger(__name__)
+
+
+def extract_filename_date(filename: str) -> str:
+    """Extract date from filename using YYYYMMDD pattern.
+
+    Args:
+        filename: Filename to extract date from
+
+    Returns:
+        Formatted date string (e.g., "02 Feb 2025"), or empty string if no date found
+    """
+    date_match = re.search(r"(\d{8})", filename)
+    if not date_match:
+        return ""
+    try:
+        return datetime.strptime(date_match.group(1), "%Y%m%d").strftime("%d %b %Y")
+    except ValueError:
+        return ""
+
+
+class RowPostProcessor:
+    """Tags rows with metadata and propagates dates to dateless transaction rows."""
+
+    def __init__(
+        self,
+        columns: dict[str, tuple[int | float, int | float]],
+        row_classifier: "RowClassifier",
+        template: "BankTemplate | None",
+        filename_date: str,
+        filename: str,
+    ) -> None:
+        self._columns = columns
+        self._row_classifier = row_classifier
+        self._template = template
+        self._filename_date = filename_date
+        self._filename = filename
+        self._date_col = ColumnTypeIdentifier.find_first_column_of_type(columns, "date")
+
+    def process(self, row: dict, current_date: str) -> str:
+        """Tag row with metadata and propagate date. Returns updated current_date.
+
+        Only processes rows classified as 'transaction'; others are left unchanged.
+
+        Args:
+            row: Row dictionary (modified in-place)
+            current_date: Most recently seen date
+
+        Returns:
+            Updated current_date
+        """
+        if self._row_classifier.classify(row, self._columns) != "transaction":
+            return current_date
+
+        # Date propagation
+        if self._date_col and row.get(self._date_col):
+            current_date = row[self._date_col]
+        elif self._date_col and (current_date or self._filename_date):
+            fallback_date = current_date or self._filename_date
+            row[self._date_col] = fallback_date
+            if not current_date:
+                current_date = fallback_date
+
+        # Metadata tagging
+        row["Filename"] = self._filename
+        if self._template:
+            row["document_type"] = self._template.document_type
+            row["template_id"] = self._template.id
+        else:
+            row["document_type"] = "bank_statement"
+            row["template_id"] = None
+
+        return current_date

--- a/packages/parser-core/tests/extraction/test_document_type_enrichment.py
+++ b/packages/parser-core/tests/extraction/test_document_type_enrichment.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
+from bankstatements_core.extraction.row_post_processor import RowPostProcessor
 from bankstatements_core.templates.template_model import (
     BankTemplate,
     TemplateDetectionConfig,
@@ -115,15 +116,17 @@ class TestDocumentTypeEnrichment:
     def test_bank_statement_document_type(self, bank_statement_template, basic_columns):
         """Test that bank statement template adds correct document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns,
-            template=bank_statement_template,
+            columns=basic_columns, template=bank_statement_template
         )
-
-        # Test _process_row directly
+        proc = RowPostProcessor(
+            columns=basic_columns,
+            row_classifier=extractor._row_classifier,
+            template=bank_statement_template,
+            filename_date="",
+            filename="test_bank.pdf",
+        )
         row = {"Date": "01/12/2023", "Details": "Purchase", "Debit €": "100.00"}
-        extractor._process_row(row, "", "", "test_bank.pdf")
-
-        # Should have document_type = "bank_statement"
+        proc.process(row, "")
         assert "document_type" in row
         assert row["document_type"] == "bank_statement"
         assert row["Filename"] == "test_bank.pdf"
@@ -131,15 +134,17 @@ class TestDocumentTypeEnrichment:
     def test_credit_card_document_type(self, credit_card_template, basic_columns):
         """Test that credit card template adds correct document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns,
-            template=credit_card_template,
+            columns=basic_columns, template=credit_card_template
         )
-
-        # Test _process_row directly
+        proc = RowPostProcessor(
+            columns=basic_columns,
+            row_classifier=extractor._row_classifier,
+            template=credit_card_template,
+            filename_date="",
+            filename="test_card.pdf",
+        )
         row = {"Date": "02/12/2023", "Details": "Card Purchase", "Debit €": "50.00"}
-        extractor._process_row(row, "", "", "test_card.pdf")
-
-        # Should have document_type = "credit_card_statement"
+        proc.process(row, "")
         assert "document_type" in row
         assert row["document_type"] == "credit_card_statement"
         assert row["Filename"] == "test_card.pdf"
@@ -147,31 +152,33 @@ class TestDocumentTypeEnrichment:
     def test_loan_statement_document_type(self, loan_statement_template, basic_columns):
         """Test that loan statement template adds correct document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns,
-            template=loan_statement_template,
+            columns=basic_columns, template=loan_statement_template
         )
-
-        # Test _process_row directly
+        proc = RowPostProcessor(
+            columns=basic_columns,
+            row_classifier=extractor._row_classifier,
+            template=loan_statement_template,
+            filename_date="",
+            filename="test_loan.pdf",
+        )
         row = {"Date": "03/12/2023", "Details": "Loan Payment", "Debit €": "200.00"}
-        extractor._process_row(row, "", "", "test_loan.pdf")
-
-        # Should have document_type = "loan_statement"
+        proc.process(row, "")
         assert "document_type" in row
         assert row["document_type"] == "loan_statement"
         assert row["Filename"] == "test_loan.pdf"
 
     def test_no_template_defaults_to_bank_statement(self, basic_columns):
         """Test that absence of template defaults to 'bank_statement'."""
-        extractor = PDFTableExtractor(
+        extractor = PDFTableExtractor(columns=basic_columns, template=None)
+        proc = RowPostProcessor(
             columns=basic_columns,
-            template=None,  # No template provided
+            row_classifier=extractor._row_classifier,
+            template=None,
+            filename_date="",
+            filename="test_unknown.pdf",
         )
-
-        # Test _process_row directly
         row = {"Date": "04/12/2023", "Details": "Unknown", "Debit €": "75.00"}
-        extractor._process_row(row, "", "", "test_unknown.pdf")
-
-        # Should default to "bank_statement"
+        proc.process(row, "")
         assert "document_type" in row
         assert row["document_type"] == "bank_statement"
 
@@ -180,15 +187,17 @@ class TestDocumentTypeEnrichment:
     ):
         """Test that document_type is added alongside Filename."""
         extractor = PDFTableExtractor(
-            columns=basic_columns,
-            template=credit_card_template,
+            columns=basic_columns, template=credit_card_template
         )
-
-        # Test _process_row directly
+        proc = RowPostProcessor(
+            columns=basic_columns,
+            row_classifier=extractor._row_classifier,
+            template=credit_card_template,
+            filename_date="",
+            filename="test_card.pdf",
+        )
         row = {"Date": "05/12/2023", "Details": "Purchase", "Debit €": "25.00"}
-        extractor._process_row(row, "", "", "test_card.pdf")
-
-        # Should have both Filename and document_type
+        proc.process(row, "")
         assert "Filename" in row
         assert "document_type" in row
         assert row["Filename"] == "test_card.pdf"
@@ -201,20 +210,22 @@ class TestDocumentTypeIntegration:
     def test_multiple_rows_same_template(self, credit_card_template, basic_columns):
         """Test that multiple rows from same template have same document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns,
-            template=credit_card_template,
+            columns=basic_columns, template=credit_card_template
         )
-
+        proc = RowPostProcessor(
+            columns=basic_columns,
+            row_classifier=extractor._row_classifier,
+            template=credit_card_template,
+            filename_date="",
+            filename="card.pdf",
+        )
         rows = [
             {"Date": "01/12/2023", "Details": "Purchase 1", "Debit €": "100.00"},
             {"Date": "02/12/2023", "Details": "Purchase 2", "Debit €": "50.00"},
             {"Date": "03/12/2023", "Details": "Purchase 3", "Debit €": "75.00"},
         ]
-
         for row in rows:
-            extractor._process_row(row, "", "", "card.pdf")
-
-        # All rows should have same document_type
+            proc.process(row, "")
         assert all(row["document_type"] == "credit_card_statement" for row in rows)
 
     def test_document_type_field_is_string(
@@ -222,14 +233,17 @@ class TestDocumentTypeIntegration:
     ):
         """Test that document_type field is always a string."""
         extractor = PDFTableExtractor(
-            columns=basic_columns,
-            template=bank_statement_template,
+            columns=basic_columns, template=bank_statement_template
         )
-
+        proc = RowPostProcessor(
+            columns=basic_columns,
+            row_classifier=extractor._row_classifier,
+            template=bank_statement_template,
+            filename_date="",
+            filename="test.pdf",
+        )
         row = {"Date": "01/12/2023", "Details": "Test", "Debit €": "100.00"}
-        extractor._process_row(row, "", "", "test.pdf")
-
-        # Verify document_type is a string
+        proc.process(row, "")
         assert isinstance(row.get("document_type"), str)
         assert row["document_type"] in [
             "bank_statement",

--- a/packages/parser-core/tests/extraction/test_page_header_analyser.py
+++ b/packages/parser-core/tests/extraction/test_page_header_analyser.py
@@ -1,0 +1,118 @@
+"""Tests for PageHeaderAnalyser."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from bankstatements_core.extraction.page_header_analyser import PageHeaderAnalyser
+
+
+def _make_page(header_text: str = "", words: list[dict] | None = None) -> Mock:
+    """Build a minimal mock pdfplumber page."""
+    page = Mock()
+    page.width = 600
+    cropped = Mock()
+    cropped.extract_text.return_value = header_text
+    cropped.extract_words.return_value = words or []
+    page.crop.return_value = cropped
+    return page
+
+
+class TestIsCredirCardStatement:
+    def _analyser(self) -> PageHeaderAnalyser:
+        return PageHeaderAnalyser(Mock())
+
+    def test_card_number_detected(self):
+        page = _make_page("Card Number: 1234 5678 9012 3456")
+        assert self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_credit_limit_detected(self):
+        page = _make_page("Credit Limit: €5,000")
+        assert self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_credit_card_phrase_detected(self):
+        page = _make_page("Your Credit Card Statement")
+        assert self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_visa_detected(self):
+        page = _make_page("VISA Debit Statement")
+        assert self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_mastercard_detected(self):
+        page = _make_page("Mastercard Gold")
+        assert self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_normal_statement_not_detected(self):
+        page = _make_page("Current Account Statement\nIBAN: IE29AIBK93115212345678")
+        assert not self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_empty_header_returns_false(self):
+        page = _make_page("")
+        assert not self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_none_header_text_returns_false(self):
+        page = _make_page(None)
+        assert not self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_page_exception_returns_false(self):
+        page = Mock()
+        page.width = 600
+        page.crop.side_effect = AttributeError("no crop")
+        assert not self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_case_insensitive(self):
+        page = _make_page("card number: 0000 1111")
+        assert self._analyser().is_credit_card_statement(page, table_top_y=300)
+
+    def test_crops_at_table_top_y(self):
+        page = _make_page("Card Number: x")
+        analyser = self._analyser()
+        analyser.is_credit_card_statement(page, table_top_y=250)
+        page.crop.assert_called_once_with((0, 0, page.width, 250))
+
+
+class TestExtractIban:
+    def test_iban_found_in_text(self):
+        mock_extractor = Mock()
+        mock_extractor.extract_iban.return_value = "IE29AIBK93115212345678"
+        mock_extractor.extract_iban_from_pdf_words.return_value = None
+        page = _make_page("Account: IE29AIBK93115212345678")
+        analyser = PageHeaderAnalyser(mock_extractor)
+        assert analyser.extract_iban(page) == "IE29AIBK93115212345678"
+
+    def test_iban_found_in_words_when_text_fails(self):
+        mock_extractor = Mock()
+        mock_extractor.extract_iban.return_value = None
+        mock_extractor.extract_iban_from_pdf_words.return_value = (
+            "IE29AIBK93115212345678"
+        )
+        page = _make_page("", words=[{"text": "IE29AIBK93115212345678"}])
+        analyser = PageHeaderAnalyser(mock_extractor)
+        assert analyser.extract_iban(page) == "IE29AIBK93115212345678"
+
+    def test_returns_none_when_no_iban(self):
+        mock_extractor = Mock()
+        mock_extractor.extract_iban.return_value = None
+        mock_extractor.extract_iban_from_pdf_words.return_value = None
+        page = _make_page("No IBAN here")
+        analyser = PageHeaderAnalyser(mock_extractor)
+        assert analyser.extract_iban(page) is None
+
+    def test_page_exception_returns_none(self):
+        mock_extractor = Mock()
+        page = Mock()
+        page.width = 600
+        page.crop.side_effect = AttributeError("crop failed")
+        analyser = PageHeaderAnalyser(mock_extractor)
+        assert analyser.extract_iban(page) is None
+
+    def test_crops_at_fixed_350(self):
+        mock_extractor = Mock()
+        mock_extractor.extract_iban.return_value = None
+        mock_extractor.extract_iban_from_pdf_words.return_value = None
+        page = _make_page("")
+        analyser = PageHeaderAnalyser(mock_extractor)
+        analyser.extract_iban(page)
+        page.crop.assert_called_once_with((0, 0, page.width, 350))

--- a/packages/parser-core/tests/extraction/test_pdf_extractor.py
+++ b/packages/parser-core/tests/extraction/test_pdf_extractor.py
@@ -8,6 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
+from bankstatements_core.extraction.row_post_processor import (
+    RowPostProcessor,
+    extract_filename_date,
+)
 
 # Test columns configuration
 TEST_COLUMNS = {
@@ -46,21 +50,15 @@ class TestPDFTableExtractor:
 
     def test_extract_filename_date_valid(self):
         """Test extracting date from filename with valid pattern."""
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS)
-        date = extractor._extract_filename_date("statement_20230115.pdf")
-        assert date == "15 Jan 2023"
+        assert extract_filename_date("statement_20230115.pdf") == "15 Jan 2023"
 
     def test_extract_filename_date_no_pattern(self):
         """Test extracting date from filename without date pattern."""
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS)
-        date = extractor._extract_filename_date("statement.pdf")
-        assert date == ""
+        assert extract_filename_date("statement.pdf") == ""
 
     def test_extract_filename_date_invalid_date(self):
         """Test extracting invalid date from filename."""
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS)
-        date = extractor._extract_filename_date("statement_99999999.pdf")
-        assert date == ""
+        assert extract_filename_date("statement_99999999.pdf") == ""
 
     def test_extract_rows_from_words(self):
         """Test extracting rows from word list."""
@@ -77,7 +75,7 @@ class TestPDFTableExtractor:
             {"text": "Sale", "x0": 60, "x1": 90, "top": 370.0},
             {"text": "25.00", "x0": 260, "x1": 290, "top": 370.0},
         ]
-        rows = extractor._extract_rows_from_words(words)
+        rows = extractor._row_builder.build_rows(words)
         assert len(rows) == 2
         assert "01 Jan" in rows[0]["Date"]
         assert "Purchase" in rows[0]["Details"]
@@ -96,13 +94,20 @@ class TestPDFTableExtractor:
             {"text": "Date", "x0": 30, "x1": 60, "top": 370},
             {"text": "Details", "x0": 60, "x1": 110, "top": 370},
         ]
-        rows = extractor._extract_rows_from_words(words)
+        rows = extractor._row_builder.build_rows(words)
         # Should only have the transaction, not the header
         assert len(rows) == 1
 
     def test_process_row_with_date(self):
         """Test processing row with date present."""
         extractor = PDFTableExtractor(columns=TEST_COLUMNS)
+        proc = RowPostProcessor(
+            columns=TEST_COLUMNS,
+            row_classifier=extractor._row_classifier,
+            template=None,
+            filename_date="",
+            filename="test.pdf",
+        )
         row = {
             "Date": "01 Jan 2023",
             "Details": "Purchase",
@@ -110,15 +115,20 @@ class TestPDFTableExtractor:
             "Credit €": "",
             "Balance €": "100.00",
         }
-        current_date = extractor._process_row(
-            row, current_date="", filename_date="", filename="test.pdf"
-        )
+        current_date = proc.process(row, current_date="")
         assert current_date == "01 Jan 2023"
         assert row["Filename"] == "test.pdf"
 
     def test_process_row_without_date_uses_current(self):
         """Test processing row without date uses current date."""
         extractor = PDFTableExtractor(columns=TEST_COLUMNS)
+        proc = RowPostProcessor(
+            columns=TEST_COLUMNS,
+            row_classifier=extractor._row_classifier,
+            template=None,
+            filename_date="",
+            filename="test.pdf",
+        )
         row = {
             "Date": "",
             "Details": "Purchase",
@@ -126,18 +136,20 @@ class TestPDFTableExtractor:
             "Credit €": "",
             "Balance €": "100.00",
         }
-        current_date = extractor._process_row(
-            row,
-            current_date="31 Dec 2022",
-            filename_date="",
-            filename="test.pdf",
-        )
+        current_date = proc.process(row, current_date="31 Dec 2022")
         assert row["Date"] == "31 Dec 2022"
         assert current_date == "31 Dec 2022"
 
     def test_process_row_without_date_uses_filename_date(self):
         """Test processing row without date uses filename date."""
         extractor = PDFTableExtractor(columns=TEST_COLUMNS)
+        proc = RowPostProcessor(
+            columns=TEST_COLUMNS,
+            row_classifier=extractor._row_classifier,
+            template=None,
+            filename_date="15 Jan 2023",
+            filename="test.pdf",
+        )
         row = {
             "Date": "",
             "Details": "Purchase",
@@ -145,12 +157,7 @@ class TestPDFTableExtractor:
             "Credit €": "",
             "Balance €": "100.00",
         }
-        current_date = extractor._process_row(
-            row,
-            current_date="",
-            filename_date="15 Jan 2023",
-            filename="test.pdf",
-        )
+        current_date = proc.process(row, current_date="")
         assert row["Date"] == "15 Jan 2023"
         assert current_date == "15 Jan 2023"
 

--- a/packages/parser-core/tests/extraction/test_row_builder.py
+++ b/packages/parser-core/tests/extraction/test_row_builder.py
@@ -1,0 +1,126 @@
+"""Tests for RowBuilder."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from bankstatements_core.extraction.row_builder import RowBuilder
+
+TEST_COLUMNS = {
+    "Date": (0, 50),
+    "Details": (50, 200),
+    "Debit €": (200, 250),
+    "Credit €": (250, 300),
+    "Balance €": (300, 350),
+}
+
+
+def _make_classifier(side_effect=None, return_value="transaction"):
+    classifier = Mock()
+    if side_effect:
+        classifier.classify.side_effect = side_effect
+    else:
+        classifier.classify.return_value = return_value
+    return classifier
+
+
+class TestRowBuilder:
+    def test_transaction_row_returned(self):
+        classifier = _make_classifier(return_value="transaction")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        words = [
+            {"text": "01/01", "x0": 5, "x1": 40, "top": 320},
+            {"text": "Tesco", "x0": 60, "x1": 110, "top": 320},
+            {"text": "12.50", "x0": 210, "x1": 245, "top": 320},
+        ]
+        rows = builder.build_rows(words)
+        assert len(rows) == 1
+        assert rows[0]["Date"] == "01/01"
+        assert rows[0]["Details"] == "Tesco"
+
+    def test_metadata_row_excluded(self):
+        classifier = _make_classifier(return_value="metadata")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        words = [{"text": "Some footer", "x0": 60, "x1": 150, "top": 320}]
+        rows = builder.build_rows(words)
+        assert rows == []
+
+    def test_continuation_row_included(self):
+        classifier = _make_classifier(return_value="continuation")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        words = [{"text": "continued desc", "x0": 60, "x1": 180, "top": 325}]
+        rows = builder.build_rows(words)
+        assert len(rows) == 1
+
+    def test_only_transactions_returned_mixed(self):
+        def classify(row, cols):
+            return "transaction" if row.get("Details") else "metadata"
+
+        classifier = _make_classifier(side_effect=classify)
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        # Row at y=320 has Details → transaction; row at y=400 has no Details → metadata
+        words = [
+            {"text": "Tesco", "x0": 60, "x1": 110, "top": 320},
+            {
+                "text": "NoDetails",
+                "x0": 5,
+                "x1": 40,
+                "top": 400,
+            },  # lands in Date column only
+        ]
+        rows = builder.build_rows(words)
+        assert len(rows) == 1
+        assert rows[0]["Details"] == "Tesco"
+
+    def test_rightmost_column_strict_boundary(self):
+        """Word that starts inside rightmost column but extends beyond should be excluded."""
+        classifier = _make_classifier(return_value="transaction")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        # x1=360 exceeds Balance € xmax=350 → strict check fails
+        words = [
+            {"text": "Tesco", "x0": 60, "x1": 110, "top": 320},
+            {"text": "1234.56", "x0": 305, "x1": 360, "top": 320},  # bleeds past 350
+        ]
+        rows = builder.build_rows(words)
+        assert len(rows) == 1
+        assert rows[0]["Balance €"] == ""  # strict boundary rejected it
+
+    def test_rightmost_column_strict_boundary_accepts_contained_word(self):
+        """Word fully contained within rightmost column should be accepted."""
+        classifier = _make_classifier(return_value="transaction")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        words = [
+            {"text": "Tesco", "x0": 60, "x1": 110, "top": 320},
+            {"text": "100.00", "x0": 305, "x1": 345, "top": 320},  # within 300–350
+        ]
+        rows = builder.build_rows(words)
+        assert rows[0]["Balance €"] == "100.00"
+
+    def test_words_grouped_by_y(self):
+        classifier = _make_classifier(return_value="transaction")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        words = [
+            {"text": "01/01", "x0": 5, "x1": 40, "top": 320},
+            {"text": "Tesco", "x0": 60, "x1": 110, "top": 320},
+            {"text": "02/01", "x0": 5, "x1": 40, "top": 340},
+            {"text": "Lidl", "x0": 60, "x1": 100, "top": 340},
+        ]
+        rows = builder.build_rows(words)
+        assert len(rows) == 2
+        assert rows[0]["Date"] == "01/01"
+        assert rows[1]["Date"] == "02/01"
+
+    def test_empty_words_returns_empty(self):
+        builder = RowBuilder(TEST_COLUMNS, _make_classifier())
+        assert builder.build_rows([]) == []
+
+    def test_x1_estimated_when_missing(self):
+        """Words without x1 should still be placed using estimated width."""
+        classifier = _make_classifier(return_value="transaction")
+        builder = RowBuilder(TEST_COLUMNS, classifier)
+        # No x1 key; estimation: x0 + max(len("Hi")*3, 10) = 5 + 10 = 15
+        words = [{"text": "Hi", "x0": 60, "top": 320}]
+        rows = builder.build_rows(words)
+        assert len(rows) == 1

--- a/packages/parser-core/tests/extraction/test_row_post_processor.py
+++ b/packages/parser-core/tests/extraction/test_row_post_processor.py
@@ -1,0 +1,160 @@
+"""Tests for RowPostProcessor and extract_filename_date."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from bankstatements_core.extraction.row_post_processor import (
+    RowPostProcessor,
+    extract_filename_date,
+)
+
+TEST_COLUMNS = {
+    "Date": (0, 50),
+    "Details": (50, 200),
+    "Debit €": (200, 250),
+    "Credit €": (250, 300),
+    "Balance €": (300, 350),
+}
+
+
+def _make_classifier(row_type="transaction"):
+    c = Mock()
+    c.classify.return_value = row_type
+    return c
+
+
+def _make_processor(
+    filename="statement.pdf", filename_date="", template=None, row_type="transaction"
+):
+    return RowPostProcessor(
+        columns=TEST_COLUMNS,
+        row_classifier=_make_classifier(row_type),
+        template=template,
+        filename_date=filename_date,
+        filename=filename,
+    )
+
+
+class TestExtractFilenameDate:
+    def test_valid_date_extracted(self):
+        assert extract_filename_date("statement_20250202.pdf") == "02 Feb 2025"
+
+    def test_no_date_returns_empty(self):
+        assert extract_filename_date("statement.pdf") == ""
+
+    def test_invalid_date_returns_empty(self):
+        assert extract_filename_date("file_99991399.pdf") == ""
+
+    def test_date_at_start(self):
+        assert extract_filename_date("20240101_bank.pdf") == "01 Jan 2024"
+
+
+class TestRowPostProcessor:
+    def test_date_propagated_from_row(self):
+        proc = _make_processor()
+        row = {
+            "Date": "01/01/2024",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        updated = proc.process(row, "")
+        assert updated == "01/01/2024"
+
+    def test_current_date_propagated_to_dateless_row(self):
+        proc = _make_processor()
+        row = {
+            "Date": "",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        updated = proc.process(row, "01/01/2024")
+        assert row["Date"] == "01/01/2024"
+        assert updated == "01/01/2024"
+
+    def test_filename_date_used_when_no_current_date(self):
+        proc = _make_processor(filename_date="15 Mar 2025")
+        row = {
+            "Date": "",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        updated = proc.process(row, "")
+        assert row["Date"] == "15 Mar 2025"
+        assert updated == "15 Mar 2025"
+
+    def test_filename_tagged(self):
+        proc = _make_processor(filename="my_statement.pdf")
+        row = {
+            "Date": "01/01",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        proc.process(row, "")
+        assert row["Filename"] == "my_statement.pdf"
+
+    def test_default_document_type_when_no_template(self):
+        proc = _make_processor(template=None)
+        row = {
+            "Date": "01/01",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        proc.process(row, "")
+        assert row["document_type"] == "bank_statement"
+        assert row["template_id"] is None
+
+    def test_template_document_type_and_id(self):
+        template = Mock()
+        template.document_type = "current_account"
+        template.id = "aib_current"
+        proc = _make_processor(template=template)
+        row = {
+            "Date": "01/01",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        proc.process(row, "")
+        assert row["document_type"] == "current_account"
+        assert row["template_id"] == "aib_current"
+
+    def test_non_transaction_row_not_modified(self):
+        proc = _make_processor(row_type="metadata")
+        row = {
+            "Date": "",
+            "Details": "Opening Balance",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        updated = proc.process(row, "05/01/2024")
+        assert "Filename" not in row
+        assert updated == "05/01/2024"
+
+    def test_current_date_not_overwritten_by_filename_date(self):
+        """filename_date should only be used when current_date is also empty."""
+        proc = _make_processor(filename_date="01 Jan 2025")
+        row = {
+            "Date": "",
+            "Details": "Tesco",
+            "Debit €": "",
+            "Credit €": "",
+            "Balance €": "",
+        }
+        updated = proc.process(row, "15/03/2025")
+        assert row["Date"] == "15/03/2025"  # current_date wins over filename_date
+        assert updated == "15/03/2025"

--- a/packages/parser-core/tests/test_credit_card_detection.py
+++ b/packages/parser-core/tests/test_credit_card_detection.py
@@ -278,7 +278,12 @@ class TestCreditCardDetection:
         mock_header.extract_text.return_value = "Statement for Card Number 1234"
         mock_page.crop.return_value = mock_header
 
-        assert extractor._is_credit_card_statement(mock_page) is True
+        assert (
+            extractor._header_analyser.is_credit_card_statement(
+                mock_page, extractor.table_top_y
+            )
+            is True
+        )
 
     def test_is_credit_card_statement_method_no_match(self):
         """Test _is_credit_card_statement with no match."""
@@ -293,7 +298,12 @@ class TestCreditCardDetection:
         mock_header.extract_text.return_value = "Bank Statement IBAN IE291234"
         mock_page.crop.return_value = mock_header
 
-        assert extractor._is_credit_card_statement(mock_page) is False
+        assert (
+            extractor._header_analyser.is_credit_card_statement(
+                mock_page, extractor.table_top_y
+            )
+            is False
+        )
 
     def test_visa_in_transaction_not_detected(self):
         """Test that 'VISA' in transaction lines does not trigger false positive."""
@@ -315,4 +325,9 @@ class TestCreditCardDetection:
 
         # Even though full page would have VISA in transactions,
         # we only check header, so should NOT be detected
-        assert extractor._is_credit_card_statement(mock_page) is False
+        assert (
+            extractor._header_analyser.is_credit_card_statement(
+                mock_page, extractor.table_top_y
+            )
+            is False
+        )


### PR DESCRIPTION
## Summary
Split PDFTableExtractor god class (505 lines, 7 responsibilities) into three focused collaborators so each concern is independently testable and reusable.

## Changes
- Add PageHeaderAnalyser: encapsulates credit card detection and IBAN extraction
- Add RowBuilder: encapsulates word-to-row conversion and classification filtering
- Add RowPostProcessor: encapsulates date propagation and metadata tagging
- Add extract_filename_date() module-level helper (pure, stateless)
- PDFTableExtractor now delegates to collaborators; body reduced to ~180 lines
- Update extraction __init__.py to export new classes
- Update existing tests to use new collaborators instead of private methods
- Add test_page_header_analyser.py, test_row_builder.py, test_row_post_processor.py

## Type
- [x] Refactoring

## Testing
- [x] Tests pass (coverage ≥ 91%)
- [x] Manually tested

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

Closes #18

# Pull Request

## Summary
<!-- Brief description of what this PR does and why -->

## Changes
<!-- List key changes made -->
-

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Security

## Testing
- [ ] Tests pass (coverage ≥ 91%)
- [ ] Manually tested

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed
- [ ] Documentation updated (if needed)
- [ ] No new warnings
