### PR TITLE
chore: bump bankstatements-core to 0.1.2

### DIFF
--- a/packages/parser-core/pyproject.toml
+++ b/packages/parser-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bankstatements-core"
-version = "0.1.1"
+version = "0.1.2"
 description = "Core PDF bank statement parsing library"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/parser-core/src/bankstatements_core/__version__.py
+++ b/packages/parser-core/src/bankstatements_core/__version__.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
-__version_info__ = (0, 1, 1)
+__version__ = "0.1.2"
+__version_info__ = (0, 1, 2)


### PR DESCRIPTION
## Summary

- Bump `bankstatements-core` from `0.1.1` → `0.1.2`
- `log_summary` now uses `PDFs read:` label (was `PDFs processed:`) and adds `pdfs_extracted` field with fallback to `pdf_count`
- Needed to unblock private repo PR #175 which delegates to this updated API

## Test plan

- [ ] CI passes on this branch
- [ ] After merge: tag `core-v0.1.2` on main to trigger PyPI release