### PR TITLE
docs: add THANKYOU.md

### DIFF
--- a/THANKYOU.md
+++ b/THANKYOU.md
@@ -1,0 +1,5 @@
+# Thank You
+
+Contributors to bankstatements-core — added automatically on merge.
+
+- [@longieirl](https://github.com/longieirl)


### PR DESCRIPTION
Creates the missing THANKYOU.md that the append-committers workflow expects. Without it, `git add THANKYOU.md` fails with exit 128 on every merged PR.