### PR TITLE
test: add pdfs_extracted to integration snapshot and re-baseline

### DIFF
--- a/packages/parser-core/tests/integration/snapshots/output_snapshot.json
+++ b/packages/parser-core/tests/integration/snapshots/output_snapshot.json
@@ -112,6 +112,7 @@
     "duplicates": 0,
     "pages_read": 24,
     "pdf_count": 4,
+    "pdfs_extracted": 3,
     "transactions": 467
   },
   "summary": {

--- a/packages/parser-core/tests/integration/test_output_snapshot.py
+++ b/packages/parser-core/tests/integration/test_output_snapshot.py
@@ -101,6 +101,7 @@ def test_output_snapshot(request: pytest.FixtureRequest) -> None:
     current = _build_snapshot(OUTPUT_DIR)
     current["processing_summary"] = {
         "pdf_count": summary.get("pdf_count"),
+        "pdfs_extracted": summary.get("pdfs_extracted"),
         "pages_read": summary.get("pages_read"),
         "transactions": summary.get("transactions"),
         "duplicates": summary.get("duplicates"),
@@ -127,7 +128,7 @@ def test_output_snapshot(request: pytest.FixtureRequest) -> None:
     diffs = []
 
     # Compare processing summary counts
-    for key in ("pdf_count", "pages_read", "transactions", "duplicates"):
+    for key in ("pdf_count", "pdfs_extracted", "pages_read", "transactions", "duplicates"):
         base_val = baseline.get("processing_summary", {}).get(key)
         curr_val = current.get("processing_summary", {}).get(key)
         if base_val != curr_val:


### PR DESCRIPTION
## Summary

Follow-up to #56 (#55 fix). Adds `pdfs_extracted` to the integration snapshot so the credit card PDF exclusion count is regression-tested going forward.

## Changes

- Add `pdfs_extracted` to snapshot capture and comparison loop in `test_output_snapshot.py`
- Re-baselined snapshot: `pdfs_extracted: 3` (4 PDFs read, 1 credit card excluded)

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Security

## Testing
- [x] Tests pass (coverage ≥ 91%)
- [x] Manually tested

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [ ] Documentation updated (if needed)
- [x] No new warnings