### PR TITLE
docs: add REFERENCE.md — GitHub issue RFC template and deep module guide

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -5,6 +5,7 @@ Used by Claude and developers when writing architectural refactor issues for thi
 ## Skills that use this file
 
 - [`improve-codebase-architecture`](https://github.com/mattpocock/skills/tree/main/improve-codebase-architecture) — surface architectural friction and propose deep-module refactors as GitHub issue RFCs
+- `gsd` suite — built-in Claude Code workflow tool for structured project planning, phase execution, and delivery
 
 ---
 


### PR DESCRIPTION
Adds `docs/REFERENCE.md` for use by the `/improve-codebase-architecture` skill and developers writing refactor RFCs.

## Contents

- GitHub issue RFC template (Why / Current behaviour / Expected outcome / Acceptance criteria)
- Four dependency categories (intra-layer, cross-package, cross-boundary I/O, cross-boundary time)
- Dependency strategy patterns (constructor injection, parameter injection, Port/Protocol, inline env fallback)
- Deep module checklist (Ousterhout's A Philosophy of Software Design)
- Worked examples linking to issues #62, #63, #64
