### PR TITLE
fix(#72): remove dead _CONTENT_DENSITY_SERVICE singleton

### DIFF
--- a/packages/parser-core/src/bankstatements_core/pdf_table_extractor.py
+++ b/packages/parser-core/src/bankstatements_core/pdf_table_extractor.py
@@ -80,7 +80,6 @@ _PAGE_VALIDATION_SERVICE = PageValidationService(
 _ROW_CLASSIFIER_CHAIN = create_row_classifier_chain()
 _HEADER_SERVICE = HeaderDetectionService()
 _ROW_MERGER_SERVICE = RowMergerService()
-_CONTENT_DENSITY_SERVICE = ContentDensityService()
 
 
 # Wrapper functions (backward compatibility)

--- a/packages/parser-core/tests/test_shim_singletons.py
+++ b/packages/parser-core/tests/test_shim_singletons.py
@@ -16,7 +16,7 @@ def test_validate_page_structure_reuses_singleton():
 
 
 def test_all_singletons_are_module_level():
-    """All five module-level singletons exist and are stable references."""
+    """All four module-level singletons exist and are stable references."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         import bankstatements_core.pdf_table_extractor as shim
@@ -25,4 +25,3 @@ def test_all_singletons_are_module_level():
     assert shim._ROW_CLASSIFIER_CHAIN is shim._ROW_CLASSIFIER_CHAIN
     assert shim._HEADER_SERVICE is shim._HEADER_SERVICE
     assert shim._ROW_MERGER_SERVICE is shim._ROW_MERGER_SERVICE
-    assert shim._CONTENT_DENSITY_SERVICE is shim._CONTENT_DENSITY_SERVICE


### PR DESCRIPTION
## Summary

Removes the dead `_CONTENT_DENSITY_SERVICE = ContentDensityService()` singleton from `pdf_table_extractor.py` (line 83).

This instance was constructed at module load and held in memory but never referenced — `analyze_content_density()` already correctly constructs a fresh `ContentDensityService(window_size=window_size)` per call because `window_size` varies per caller. The singleton was misleading and wasteful.

- Removes 1 line from `pdf_table_extractor.py`
- Updates `test_shim_singletons.py` docstring and assertion count from 5 to 4 singletons
- All 1400 tests pass

Closes #72

## PR Checklist

- [x] Tests pass locally
- [x] No new dependencies introduced
- [x] No public API changes
- [ ] Docker integration test run (blocked — see #59)
