### PR TITLE
ci: add [skip downstream] support to dispatch-downstream job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,9 @@ jobs:
   # Fires only on push to main (not PRs), only when parser-core files changed,
   # and only after test-core passes.
   #
+  # To skip the downstream trigger (e.g. formatting fixes, doc updates):
+  #   add [skip downstream] anywhere in the commit message.
+  #
   # Security:
   #   - Gated on push to main + test-core success — PRs never trigger this
   #   - DOWNSTREAM_DISPATCH_TOKEN must be a fine-grained PAT scoped to
@@ -376,7 +379,10 @@ jobs:
     name: Dispatch downstream CI (bankstatements)
     runs-on: ubuntu-latest
     needs: test-core
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      !contains(github.event.head_commit.message, '[skip downstream]')
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Adds `[skip downstream]` commit message flag to skip the `dispatch-downstream` job in `ci.yml`. Closes #81.

Every merge to `main` currently triggers a full CI run in the private `longieirl/bankstatements` repo (~7–8 minutes, counted against the 3,000 free minutes/month). Many merges (formatting fixes, doc updates, test-only changes) don't need to trigger a private-repo rebuild.

## Changes

- `dispatch-downstream` job condition extended to skip when commit message contains `[skip downstream]`
- Comment block updated to document the flag

## Usage

```
git commit -m "style: black formatting fix [skip downstream]"
git commit -m "docs: update CHANGELOG [skip downstream]"
git commit -m "test: add regression test [skip downstream]"
```

## Test Plan

- [ ] Merge a commit to `main` with `[skip downstream]` in the message — verify `dispatch-downstream` job is skipped in Actions
- [ ] Merge a commit without the flag — verify dispatch still fires as normal
- [ ] Verify `ci-pass` still succeeds when `dispatch-downstream` is skipped (it's not in the `ci-pass` needs list, so no impact

## Related
- #81 — CI: reduce GitHub Actions minutes consumption in private bankstatements repo
EOF
)