### PR TITLE
ci: add downstream impact checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,3 +26,7 @@
 - [ ] Self-reviewed
 - [ ] Documentation updated (if needed)
 - [ ] No new warnings
+
+## Downstream impact
+- [ ] This PR changes a public interface in `bankstatements_core` (exported class, function, or exception)
+  <!-- If checked: describe what changed and what the private repo needs to update -->


### PR DESCRIPTION
## Summary

Adds a **Downstream impact** section to the PR template with a checkbox for PRs that change public `bankstatements_core` interfaces.

## Why

The private `longieirl/bankstatements` repo consumes `bankstatements-core` from PyPI. When a public interface changes (exported class, function, or exception), the premium code may need updating before the next core release lands. Without a signal on the PR, this dependency is invisible until CI breaks.

## How it works

When the checkbox is checked, the PR author describes what changed and what the private repo needs to update. Combined with a `breaking-downstream` label (to be added as a repo label), these PRs are searchable and reviewable before the core version is published.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — add Downstream impact section

Closes Part 2 of longieirl/bankstatements#189 (public-repo task).
