### PR TITLE
ci(#87): add Hadolint + pin trivy-action to SHA

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,7 +49,7 @@ jobs:
         tags: bankstatementsprocessor:pr-scan
 
     - name: Run Trivy vulnerability scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       with:
         image-ref: 'bankstatementsprocessor:pr-scan'
         format: 'table'
@@ -58,7 +58,7 @@ jobs:
         ignore-unfixed: true
 
     - name: Run Trivy scan for secrets
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       with:
         image-ref: 'bankstatementsprocessor:pr-scan'
         format: 'table'
@@ -92,7 +92,7 @@ jobs:
         docker images ghcr.io/longieirl/bankstatements:latest
 
     - name: Run comprehensive Trivy scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       with:
         image-ref: 'ghcr.io/longieirl/bankstatements:latest'
         format: 'table'
@@ -101,7 +101,7 @@ jobs:
         exit-code: '0'  # Don't fail, just report
 
     - name: Run Trivy scan for secrets
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       with:
         image-ref: 'ghcr.io/longieirl/bankstatements:latest'
         format: 'table'
@@ -109,7 +109,7 @@ jobs:
         exit-code: '1'  # Fail if secrets found
 
     - name: Run Trivy scan for misconfigurations
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       with:
         image-ref: 'ghcr.io/longieirl/bankstatements:latest'
         format: 'table'
@@ -117,7 +117,7 @@ jobs:
         exit-code: '0'  # Don't fail, just report
 
     - name: Generate Trivy SARIF report
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       with:
         image-ref: 'ghcr.io/longieirl/bankstatements:latest'
         format: 'sarif'
@@ -127,7 +127,7 @@ jobs:
     # Detailed security reports are available as workflow artifacts
 
     - name: Generate detailed JSON report
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
       if: always()
       with:
         image-ref: 'ghcr.io/longieirl/bankstatements:latest'

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,10 @@
+# Hadolint configuration
+# https://github.com/hadolint/hadolint#configure
+#
+# DL3008 (unpinned apt packages) is suppressed per-line in the Dockerfile with inline comments
+# rather than globally here, so the rationale is visible at the point of suppression.
+#
+# DL3009 (delete apt lists in a separate RUN) is NOT suppressed — both apt-get install steps
+# already clean up in the same RUN layer so this rule passes cleanly.
+
+failure-threshold: error

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,12 +75,11 @@ repos:
         args: ['--baseline', '.secrets.baseline']
         exclude: package.lock.json
 
-  # Docker linting (disabled - requires hadolint binary installation)
-  # - repo: https://github.com/hadolint/hadolint
-  #   rev: v2.12.0
-  #   hooks:
-  #     - id: hadolint-docker
-  #       args: [--ignore, DL3008, --ignore, DL3009]
+  # Docker linting
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker
 
   # Markdown linting (disabled - requires npm package installation)
   # - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,11 @@ ARG VCS_REF
 # ============================================================================
 FROM base AS builder
 
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     && rm -rf /var/lib/apt/lists/*
+# gcc is builder-stage only — never reaches the production image; DL3008 suppressed.
 
 RUN pip install --no-cache-dir --upgrade pip wheel setuptools build
 
@@ -34,9 +36,11 @@ RUN python -c "import sysconfig; print(sysconfig.get_path('purelib'))" | xargs -
 # ============================================================================
 FROM base AS production
 
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     poppler-utils \
     && rm -rf /var/lib/apt/lists/*
+# poppler-utils is runtime-critical; pinning not practical. Mitigated by Trivy CI gate.
 
 RUN groupadd -r appuser && useradd -r -g appuser -u 1000 appuser
 


### PR DESCRIPTION
# Pull Request

## Summary
Implements SEC-02: adds Hadolint Dockerfile linting and pins `trivy-action` from `@master` to a full commit SHA.

The `@master` pin was a real risk — in March 2026 Aquasec's ecosystem was compromised with malicious force-pushes to trivy-action tags, making SHA pinning a documented necessity rather than a theoretical concern.

Closes #87

## Changes

### Dockerfile
- `# hadolint ignore=DL3008` added inline immediately above each `apt-get install` step:
  - Builder stage (`gcc`): discarded at stage boundary, never ships to production
  - Production stage (`poppler-utils`): runtime-critical; version pinning not practical; mitigated by Trivy CI gate
- DL3009 passes cleanly — cleanup already in the same `RUN` layer

### `.hadolint.yaml` (new)
- `failure-threshold: error` — warnings don't block, errors do
- DL3008 suppression is per-line in the Dockerfile (visible at point of suppression), not global

### `.pre-commit-config.yaml`
- Enabled `hadolint-docker` hook at `rev: v2.14.0` (was commented out with stale v2.12.0 + blanket DL3008/DL3009 ignore args)

### `security-scan.yml`
- All 7 `aquasecurity/trivy-action@master` replaced with `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0`
- SHA verified against the v0.35.0 tag (latest stable as of 2026-03-30)
- Dependabot `github-actions` ecosystem already configured to track SHA-pinned actions via version updates

## Type
- [x] Security
- [x] CI

## Testing
- [x] Hadolint run locally via Docker — DL3008 suppressed on both `apt-get` lines, all remaining output is pre-existing warnings (not errors)
- [x] `yamllint -d relaxed` — no errors on changed YAML files
- [x] black ✅ · isort ✅ · ruff ✅ — both packages clean
- [x] Tests pass (1422 parser-core, 88 parser-free)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core`