### PR TITLE
fix(#86): replace safety with pip-audit for dependency vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 #   changes     — detect which paths changed (skips heavy jobs on workflow-only PRs)
 #   lint-core   — black, isort, ruff, mypy on packages/parser-core
 #   lint-free   — black, isort, ruff on packages/parser-free
-#   security    — bandit + safety on both packages
+#   security    — bandit + pip-audit on both packages
 #   test-core   — pytest with 91% coverage gate (Python matrix), needs lint-core
 #   test-free   — pytest on packages/parser-free, needs lint-free
 
@@ -174,7 +174,7 @@ jobs:
       run: ruff check src tests
 
   security:
-    name: Security — bandit + safety
+    name: Security — bandit + pip-audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: changes
@@ -194,7 +194,7 @@ jobs:
 
     - name: Install security tools + packages
       run: |
-        pip install --upgrade pip bandit[toml] safety
+        pip install --upgrade pip bandit[toml] pip-audit
         pip install -e packages/parser-core
         pip install -e packages/parser-free
 
@@ -204,8 +204,8 @@ jobs:
     - name: Bandit — parser-free
       run: bandit -r packages/parser-free/src -f json -o bandit-free.json || true
 
-    - name: Safety scan
-      run: safety scan --json > safety-report.json || true
+    - name: pip-audit — dependency vulnerability scan
+      run: pip-audit -r requirements/base.txt --progress-spinner off -f json -o pip-audit-report.json
 
     - name: Upload security reports
       uses: actions/upload-artifact@v7
@@ -215,7 +215,7 @@ jobs:
         path: |
           bandit-core.json
           bandit-free.json
-          safety-report.json
+          pip-audit-report.json
 
   # ---------------------------------------------------------------------------
   # Test jobs (serial after their respective lint job)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 
 # Security scanning
 bandit==1.9.4
-safety==3.7.0
+pip-audit>=2.7.0
 
 # License compliance
 pip-licenses>=5.0.0


### PR DESCRIPTION
## Summary
Replaces `safety` with `pip-audit` as the dependency vulnerability scanner in CI. The old `safety scan` step was advisory-only (`|| true`) and never blocked the pipeline. `pip-audit` runs as a hard gate — any known vulnerability in `requirements/base.txt` fails the build.

Baseline advisory run confirmed zero current violations before switching to enforcement.

## Changes
- `.github/workflows/ci.yml`: replace `safety scan --json > safety-report.json || true` with `pip-audit -r requirements/base.txt --progress-spinner off -f json -o pip-audit-report.json` (hard gate, no `|| true`)
- `.github/workflows/ci.yml`: update job name, install step, and uploaded artifact name
- `requirements/ci.txt`: remove `safety==3.7.0`, add `pip-audit>=2.7.0`

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Security

## Testing
- [x] Tests pass (coverage ≥ 91%)
- [x] Manually tested
- [ ] `make docker-integration` passed locally *(required when touching `Dockerfile`, `entrypoint.sh`, `docker-compose.yml`, or `packages/parser-core/`)*

Local baseline: `pip-audit -r requirements/base.txt --progress-spinner off` → `No known vulnerabilities found`

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core` (exported class, function, or exception)