### PR TITLE
fix(#129): filter non-transaction rows from output

### DIFF
--- a/packages/parser-core/src/bankstatements_core/extraction/row_post_processor.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/row_post_processor.py
@@ -195,7 +195,7 @@ class StatefulPageRowProcessor:
         for row in page_rows:
             self._current_date = self._post_processor.process(row, self._current_date)
             self._last_source = self._post_processor._last_source
-            if row:
+            if row.get("Filename"):
                 result.append(row)
         return result
 


### PR DESCRIPTION
## Summary

Closes #129

- Changed `if row:` to `if row.get("Filename"):` in `StatefulPageRowProcessor.process_page()`
- `Filename` is only stamped by `RowPostProcessor` on rows that pass transaction classification — making it a reliable sentinel to exclude headers, totals, and blank rows

## Test plan
- [x] 1484 unit tests passed locally
- [x] Integration snapshot: `bank_statements_9459` row count 22 → 15 (7 empty rows removed)