### PR TITLE
refactor(#109): introduce PDFExtractorOptions to reduce PDFTableExtractor constructor params

### DIFF
--- a/packages/parser-core/src/bankstatements_core/commands/analyze_pdf.py
+++ b/packages/parser-core/src/bankstatements_core/commands/analyze_pdf.py
@@ -22,6 +22,7 @@ from bankstatements_core.analysis.column_analyzer import ColumnAnalyzer
 from bankstatements_core.analysis.iban_spatial_filter import IBANSpatialFilter
 from bankstatements_core.analysis.table_detector import TableDetector
 from bankstatements_core.analysis.template_generator import TemplateGenerator
+from bankstatements_core.extraction.extraction_params import PDFExtractorOptions
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
 
 logger = logging.getLogger(__name__)
@@ -290,10 +291,14 @@ class PDFAnalyzer:
             # This bypasses entitlement system
             extractor = PDFTableExtractor(
                 columns=columns,
-                table_top_y=table_top_y,
-                table_bottom_y=table_bottom_y,
-                header_check_top_y=extraction_config.get("header_check_top_y", 0),
-                enable_header_check=extraction_config.get("enable_header_check", True),
+                options=PDFExtractorOptions(
+                    table_top_y=table_top_y,
+                    table_bottom_y=table_bottom_y,
+                    header_check_top_y=extraction_config.get("header_check_top_y", 0),
+                    enable_header_check=extraction_config.get(
+                        "enable_header_check", True
+                    ),
+                ),
             )
 
             # Extract from first page only for validation

--- a/packages/parser-core/src/bankstatements_core/extraction/extraction_facade.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/extraction_facade.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, Any
 
 from bankstatements_core.config.column_config import DEFAULT_COLUMNS
 from bankstatements_core.domain import ExtractionResult
-from bankstatements_core.extraction.extraction_params import TABLE_BOTTOM_Y, TABLE_TOP_Y
+from bankstatements_core.extraction.extraction_params import (
+    TABLE_BOTTOM_Y,
+    TABLE_TOP_Y,
+    PDFExtractorOptions,
+)
 
 if TYPE_CHECKING:
     from bankstatements_core.extraction.row_classifiers import RowClassifier
@@ -122,15 +126,17 @@ def extract_tables_from_pdf(  # noqa: PLR0913
 
     extractor = PDFTableExtractor(
         columns=columns,
-        table_top_y=table_top_y,
-        table_bottom_y=table_bottom_y,
-        enable_dynamic_boundary=enable_dynamic_boundary,
-        enable_page_validation=enable_page_validation,
-        enable_header_check=enable_header_check,
-        header_check_top_y=header_check_top_y,
-        extraction_config=template.extraction if template is not None else None,
-        template=template,  # NEW: Pass template for document type
-        entitlements=entitlements,
+        options=PDFExtractorOptions(
+            table_top_y=table_top_y,
+            table_bottom_y=table_bottom_y,
+            enable_dynamic_boundary=enable_dynamic_boundary,
+            enable_page_validation=enable_page_validation,
+            enable_header_check=enable_header_check,
+            header_check_top_y=header_check_top_y,
+            extraction_config=template.extraction if template is not None else None,
+            template=template,
+            entitlements=entitlements,
+        ),
     )
 
     return extractor.extract(pdf_path)

--- a/packages/parser-core/src/bankstatements_core/extraction/extraction_params.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/extraction_params.py
@@ -7,7 +7,13 @@ to improve separation of concerns.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
 from bankstatements_core.config.environment_parser import EnvironmentParser
+
+if TYPE_CHECKING:
+    from bankstatements_core.templates.template_model import BankTemplate
 
 # ---- Table vertical bounds ----
 TABLE_TOP_Y = 300
@@ -48,3 +54,22 @@ ADMINISTRATIVE_PATTERNS = EnvironmentParser.parse_json_list(
     "ADMINISTRATIVE_PATTERNS",
     ["BALANCE FORWARD", "Interest Rate", "Lending @"],
 )
+
+
+@dataclass
+class PDFExtractorOptions:
+    """Configuration options for PDFTableExtractor.
+
+    Groups the optional parameters so the constructor signature stays
+    within pylint's design limit (R0913/R0917).
+    """
+
+    table_top_y: int = TABLE_TOP_Y
+    table_bottom_y: int = TABLE_BOTTOM_Y
+    enable_dynamic_boundary: bool = False
+    enable_page_validation: bool = True
+    enable_header_check: bool = True
+    header_check_top_y: int | None = None
+    extraction_config: Any | None = None
+    template: BankTemplate | None = field(default=None)
+    entitlements: Any | None = None

--- a/packages/parser-core/src/bankstatements_core/extraction/pdf_extractor.py
+++ b/packages/parser-core/src/bankstatements_core/extraction/pdf_extractor.py
@@ -20,6 +20,7 @@ from bankstatements_core.domain.models.extraction_warning import (
     CODE_CREDIT_CARD_SKIPPED,
     ExtractionWarning,
 )
+from bankstatements_core.extraction.extraction_params import PDFExtractorOptions
 from bankstatements_core.extraction.iban_extractor import IBANExtractor
 from bankstatements_core.extraction.page_header_analyser import PageHeaderAnalyser
 from bankstatements_core.extraction.row_builder import RowBuilder
@@ -43,30 +44,23 @@ class PDFTableExtractor:
     - RowPostProcessor: date propagation and metadata tagging
     """
 
-    def __init__(  # noqa: PLR0913  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(
         self,
         columns: dict[str, tuple[int | float, int | float]],
-        table_top_y: int = 300,
-        table_bottom_y: int = 720,
-        enable_dynamic_boundary: bool = False,
-        enable_page_validation: bool = True,
-        enable_header_check: bool = True,
-        header_check_top_y: int | None = None,
+        options: PDFExtractorOptions | None = None,
         pdf_reader: IPDFReader | None = None,
-        extraction_config: Any | None = None,
-        template: Any | None = None,
-        entitlements: Any | None = None,
     ):
+        opts = options or PDFExtractorOptions()
         self.columns = columns
-        self.table_top_y = table_top_y
-        self.table_bottom_y = table_bottom_y
-        self.enable_dynamic_boundary = enable_dynamic_boundary
-        self.page_validation_enabled = enable_page_validation
-        self.header_check_enabled = enable_header_check
-        self.header_check_top_y = header_check_top_y
-        self.extraction_config = extraction_config
-        self.template = template
-        self._entitlements = entitlements
+        self.table_top_y = opts.table_top_y
+        self.table_bottom_y = opts.table_bottom_y
+        self.enable_dynamic_boundary = opts.enable_dynamic_boundary
+        self.page_validation_enabled = opts.enable_page_validation
+        self.header_check_enabled = opts.enable_header_check
+        self.header_check_top_y = opts.header_check_top_y
+        self.extraction_config = opts.extraction_config
+        self.template = opts.template
+        self._entitlements = opts.entitlements
 
         self._row_classifier = create_row_classifier_chain()
         self._row_builder = RowBuilder(columns, self._row_classifier)

--- a/packages/parser-core/tests/extraction/test_document_type_enrichment.py
+++ b/packages/parser-core/tests/extraction/test_document_type_enrichment.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from bankstatements_core.extraction.extraction_params import PDFExtractorOptions
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
 from bankstatements_core.extraction.row_post_processor import RowPostProcessor
 from bankstatements_core.templates.template_model import (
@@ -116,7 +117,8 @@ class TestDocumentTypeEnrichment:
     def test_bank_statement_document_type(self, bank_statement_template, basic_columns):
         """Test that bank statement template adds correct document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns, template=bank_statement_template
+            columns=basic_columns,
+            options=PDFExtractorOptions(template=bank_statement_template),
         )
         proc = RowPostProcessor(
             columns=basic_columns,
@@ -134,7 +136,8 @@ class TestDocumentTypeEnrichment:
     def test_credit_card_document_type(self, credit_card_template, basic_columns):
         """Test that credit card template adds correct document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns, template=credit_card_template
+            columns=basic_columns,
+            options=PDFExtractorOptions(template=credit_card_template),
         )
         proc = RowPostProcessor(
             columns=basic_columns,
@@ -152,7 +155,8 @@ class TestDocumentTypeEnrichment:
     def test_loan_statement_document_type(self, loan_statement_template, basic_columns):
         """Test that loan statement template adds correct document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns, template=loan_statement_template
+            columns=basic_columns,
+            options=PDFExtractorOptions(template=loan_statement_template),
         )
         proc = RowPostProcessor(
             columns=basic_columns,
@@ -169,7 +173,7 @@ class TestDocumentTypeEnrichment:
 
     def test_no_template_defaults_to_bank_statement(self, basic_columns):
         """Test that absence of template defaults to 'bank_statement'."""
-        extractor = PDFTableExtractor(columns=basic_columns, template=None)
+        extractor = PDFTableExtractor(columns=basic_columns)
         proc = RowPostProcessor(
             columns=basic_columns,
             row_classifier=extractor._row_classifier,
@@ -187,7 +191,8 @@ class TestDocumentTypeEnrichment:
     ):
         """Test that document_type is added alongside Filename."""
         extractor = PDFTableExtractor(
-            columns=basic_columns, template=credit_card_template
+            columns=basic_columns,
+            options=PDFExtractorOptions(template=credit_card_template),
         )
         proc = RowPostProcessor(
             columns=basic_columns,
@@ -210,7 +215,8 @@ class TestDocumentTypeIntegration:
     def test_multiple_rows_same_template(self, credit_card_template, basic_columns):
         """Test that multiple rows from same template have same document_type."""
         extractor = PDFTableExtractor(
-            columns=basic_columns, template=credit_card_template
+            columns=basic_columns,
+            options=PDFExtractorOptions(template=credit_card_template),
         )
         proc = RowPostProcessor(
             columns=basic_columns,
@@ -233,7 +239,8 @@ class TestDocumentTypeIntegration:
     ):
         """Test that document_type field is always a string."""
         extractor = PDFTableExtractor(
-            columns=basic_columns, template=bank_statement_template
+            columns=basic_columns,
+            options=PDFExtractorOptions(template=bank_statement_template),
         )
         proc = RowPostProcessor(
             columns=basic_columns,

--- a/packages/parser-core/tests/extraction/test_page_skipping.py
+++ b/packages/parser-core/tests/extraction/test_page_skipping.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from bankstatements_core.extraction.extraction_params import PDFExtractorOptions
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
 
 # Test columns configuration
@@ -90,7 +91,8 @@ class TestPageSkipping:
 
         # Extract with default settings (validation enabled)
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_dynamic_boundary=True
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_dynamic_boundary=True),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -133,7 +135,8 @@ class TestPageSkipping:
         mock_cropped2.extract_words.return_value = mock_words2
 
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_dynamic_boundary=True
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_dynamic_boundary=True),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -170,7 +173,8 @@ class TestPageSkipping:
             mock_cropped.extract_words.return_value = mock_words
 
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_dynamic_boundary=True
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_dynamic_boundary=True),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -230,7 +234,8 @@ class TestPageSkipping:
         mock_cropped3.extract_words.return_value = mock_words3
 
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_dynamic_boundary=True
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_dynamic_boundary=True),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -258,7 +263,8 @@ class TestPageSkipping:
 
         # With validation disabled
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_page_validation=False
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_page_validation=False),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -288,7 +294,8 @@ class TestPageSkipping:
 
         # Create extractor with defaults (should have validation enabled)
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_dynamic_boundary=True
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_dynamic_boundary=True),
         )
 
         # Verify both validations are enabled by default
@@ -333,7 +340,10 @@ class TestPageSkipping:
         ]
         mock_cropped.extract_words.return_value = mock_words
 
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS, enable_page_validation=True)
+        extractor = PDFTableExtractor(
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_page_validation=True),
+        )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
         assert result.page_count == 1

--- a/packages/parser-core/tests/extraction/test_pdf_extractor.py
+++ b/packages/parser-core/tests/extraction/test_pdf_extractor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from bankstatements_core.domain import ExtractionResult
+from bankstatements_core.extraction.extraction_params import PDFExtractorOptions
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
 from bankstatements_core.extraction.row_post_processor import (
     RowPostProcessor,
@@ -37,10 +38,12 @@ class TestPDFTableExtractor:
         """Test extractor initialization with custom values."""
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            table_top_y=250,
-            table_bottom_y=800,
-            enable_dynamic_boundary=True,
-            enable_page_validation=True,
+            options=PDFExtractorOptions(
+                table_top_y=250,
+                table_bottom_y=800,
+                enable_dynamic_boundary=True,
+                enable_page_validation=True,
+            ),
         )
         assert extractor.table_top_y == 250
         assert extractor.table_bottom_y == 800
@@ -185,8 +188,10 @@ class TestPDFTableExtractor:
         # Extract - pass parameters directly instead of using environment variables
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+            ),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -220,9 +225,11 @@ class TestPDFTableExtractor:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_dynamic_boundary=True,
-            enable_page_validation=False,
-            enable_header_check=False,
+            options=PDFExtractorOptions(
+                enable_dynamic_boundary=True,
+                enable_page_validation=False,
+                enable_header_check=False,
+            ),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -248,7 +255,10 @@ class TestPDFTableExtractor:
         ]
         mock_cropped.extract_words.return_value = mock_words
 
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS, enable_page_validation=True)
+        extractor = PDFTableExtractor(
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_page_validation=True),
+        )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
         assert result.page_count == 1
@@ -286,8 +296,9 @@ class TestPDFTableExtractor:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
+            options=PDFExtractorOptions(
+                enable_page_validation=False, enable_header_check=False
+            ),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -326,8 +337,10 @@ class TestPDFTableExtractor:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+            ),
         )
         result = extractor.extract(Path("/tmp/test.pdf"))
 
@@ -338,20 +351,28 @@ class TestPDFTableExtractor:
 
     def test_page_validation_constructor_parameter(self):
         """Test page validation setting via constructor parameter."""
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS, enable_page_validation=True)
+        extractor = PDFTableExtractor(
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_page_validation=True),
+        )
         assert extractor.page_validation_enabled is True
 
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, enable_page_validation=False
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(enable_page_validation=False),
         )
         assert extractor.page_validation_enabled is False
 
     def test_header_check_constructor_parameter(self):
         """Test header check setting via constructor parameter."""
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS, enable_header_check=True)
+        extractor = PDFTableExtractor(
+            columns=TEST_COLUMNS, options=PDFExtractorOptions(enable_header_check=True)
+        )
         assert extractor.header_check_enabled is True
 
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS, enable_header_check=False)
+        extractor = PDFTableExtractor(
+            columns=TEST_COLUMNS, options=PDFExtractorOptions(enable_header_check=False)
+        )
         assert extractor.header_check_enabled is False
 
     def test_extraction_config_parameter(self):
@@ -369,7 +390,8 @@ class TestPDFTableExtractor:
         )
 
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, extraction_config=extraction_config
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(extraction_config=extraction_config),
         )
 
         assert extractor.extraction_config is not None
@@ -426,9 +448,11 @@ class TestPDFTableExtractor:
         # Create extractor with extraction_config
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            extraction_config=extraction_config,
-            enable_page_validation=False,
-            enable_header_check=False,
+            options=PDFExtractorOptions(
+                extraction_config=extraction_config,
+                enable_page_validation=False,
+                enable_header_check=False,
+            ),
         )
 
         result = extractor.extract(Path("/tmp/test.pdf"))
@@ -474,10 +498,12 @@ class TestPDFTableExtractor:
         # Create extractor WITHOUT extraction_config (should use instance defaults)
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            table_top_y=300,
-            table_bottom_y=720,
-            enable_page_validation=False,
-            enable_header_check=False,
+            options=PDFExtractorOptions(
+                table_top_y=300,
+                table_bottom_y=720,
+                enable_page_validation=False,
+                enable_header_check=False,
+            ),
         )
 
         result = extractor.extract(Path("/tmp/test.pdf"))
@@ -530,9 +556,11 @@ class TestPDFTableExtractor:
         # Create extractor with header check enabled
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            extraction_config=extraction_config,
-            enable_page_validation=False,
-            enable_header_check=True,  # Enable header check
+            options=PDFExtractorOptions(
+                extraction_config=extraction_config,
+                enable_page_validation=False,
+                enable_header_check=True,
+            ),
         )
 
         extractor.extract(Path("/tmp/test.pdf"))
@@ -589,10 +617,12 @@ class TestPDFTableExtractorCardNumber:
         # Header analyser: IS a CC statement
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
-            template=mock_template,
-            entitlements=mock_entitlements,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+                template=mock_template,
+                entitlements=mock_entitlements,
+            ),
         )
         extractor._header_analyser = MagicMock()
         extractor._header_analyser.is_credit_card_statement.return_value = True
@@ -620,10 +650,12 @@ class TestPDFTableExtractorCardNumber:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
-            template=None,
-            entitlements=mock_entitlements,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+                template=None,
+                entitlements=mock_entitlements,
+            ),
         )
         extractor._header_analyser = MagicMock()
         extractor._header_analyser.is_credit_card_statement.return_value = True
@@ -668,10 +700,12 @@ class TestPDFTableExtractorCardNumber:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
-            template=mock_template,
-            entitlements=mock_entitlements,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+                template=mock_template,
+                entitlements=mock_entitlements,
+            ),
         )
         extractor._header_analyser = MagicMock()
         extractor._header_analyser.is_credit_card_statement.return_value = True
@@ -704,9 +738,11 @@ class TestPDFTableExtractorCardNumber:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
-            entitlements=mock_entitlements,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+                entitlements=mock_entitlements,
+            ),
         )
         extractor._header_analyser = MagicMock()
         extractor._header_analyser.is_credit_card_statement.return_value = True
@@ -752,10 +788,12 @@ class TestPDFTableExtractorCardNumber:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
-            template=mock_template,
-            entitlements=mock_entitlements,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+                template=mock_template,
+                entitlements=mock_entitlements,
+            ),
         )
         extractor._header_analyser = MagicMock()
         extractor._header_analyser.is_credit_card_statement.return_value = True
@@ -796,10 +834,12 @@ class TestPDFTableExtractorCardNumber:
 
         extractor = PDFTableExtractor(
             columns=TEST_COLUMNS,
-            enable_page_validation=False,
-            enable_header_check=False,
-            template=mock_template,
-            entitlements=mock_entitlements,
+            options=PDFExtractorOptions(
+                enable_page_validation=False,
+                enable_header_check=False,
+                template=mock_template,
+                entitlements=mock_entitlements,
+            ),
         )
         extractor._header_analyser = MagicMock()
         extractor._header_analyser.is_credit_card_statement.return_value = True

--- a/packages/parser-core/tests/test_credit_card_detection.py
+++ b/packages/parser-core/tests/test_credit_card_detection.py
@@ -11,6 +11,7 @@ from bankstatements_core.domain.models.extraction_warning import (
     ExtractionWarning,
 )
 from bankstatements_core.entitlements import Entitlements
+from bankstatements_core.extraction.extraction_params import PDFExtractorOptions
 from bankstatements_core.extraction.pdf_extractor import PDFTableExtractor
 
 # Test columns configuration
@@ -381,7 +382,8 @@ class TestCreditCardDetection:
 
         # Paid tier: require_iban=False → credit card PDFs should proceed
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, entitlements=Entitlements.paid_tier()
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(entitlements=Entitlements.paid_tier()),
         )
         result = extractor.extract(Path("/tmp/credit_card.pdf"))
 
@@ -404,7 +406,8 @@ class TestCreditCardDetection:
         mock_page.crop.return_value = mock_header
 
         extractor = PDFTableExtractor(
-            columns=TEST_COLUMNS, entitlements=Entitlements.free_tier()
+            columns=TEST_COLUMNS,
+            options=PDFExtractorOptions(entitlements=Entitlements.free_tier()),
         )
         result = extractor.extract(Path("/tmp/credit_card.pdf"))
 
@@ -425,7 +428,7 @@ class TestCreditCardDetection:
         mock_header.extract_text.return_value = "Statement for Card Number 1234"
         mock_page.crop.return_value = mock_header
 
-        extractor = PDFTableExtractor(columns=TEST_COLUMNS, entitlements=None)
+        extractor = PDFTableExtractor(columns=TEST_COLUMNS)
         result = extractor.extract(Path("/tmp/credit_card.pdf"))
 
         assert isinstance(result, ExtractionResult)


### PR DESCRIPTION
# Pull Request

## Summary
Closes #109. `PDFTableExtractor.__init__` had 11 parameters, exceeding pylint R0913/R0917 design limit. This PR groups the optional config arguments into a `PDFExtractorOptions` dataclass, reducing the constructor to 3 parameters (`columns`, `options`, `pdf_reader`).

## Changes
- `extraction_params.py`: add `PDFExtractorOptions` dataclass with all 8 optional config fields
- `pdf_extractor.py`: replace flat keyword args with `options: PDFExtractorOptions | None = None`
- `extraction_facade.py`: update `extract_tables_from_pdf()` to construct and pass `PDFExtractorOptions`
- `commands/analyze_pdf.py`: update `_validate_extraction()` to use `PDFExtractorOptions`
- Test files updated: `test_pdf_extractor.py`, `test_page_skipping.py`, `test_document_type_enrichment.py`, `test_credit_card_detection.py`

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Security

## Testing
- [x] Tests pass (1551 passing, 4 skipped)
- [x] Manually tested
- [x] Integration test passed locally

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core` (exported class, function, or exception)
