### PR TITLE
ci: notify downstream on core PyPI publish

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -119,3 +119,28 @@ jobs:
       with:
         packages-dir: dist/
         print-hash: true
+
+  notify-downstream:
+    name: Notify downstream (bankstatements)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [ validate, publish ]
+
+    steps:
+    - name: Dispatch core-released event to private repo
+      run: |
+        curl -fsSL \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/longieirl/bankstatements/dispatches \
+          -d "{
+            \"event_type\": \"core-released\",
+            \"client_payload\": {
+              \"core_version\": \"${{ needs.validate.outputs.version }}\",
+              \"ref\": \"${{ github.ref_name }}\",
+              \"sha\": \"${{ github.sha }}\",
+              \"run_url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+            }
+          }"


### PR DESCRIPTION
## Summary
- Adds `notify-downstream` job to `release-core.yml` that fires after a successful PyPI publish
- Sends a `core-released` `repository_dispatch` event to `longieirl/bankstatements` with the new core version, SHA, and run URL in the payload
- Private repo's new `core-release-sync.yml` workflow receives this, runs tests, bumps the premium version + core pin, commits, and tags — which triggers `release.yml` to build and push the Docker image automatically

## Secrets required
- `DOWNSTREAM_DISPATCH_TOKEN` must be set in this repo's secrets — fine-grained PAT scoped to `longieirl/bankstatements` with `Contents: write`

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, tag a `core-vX.Y.Z` release and verify `notify-downstream` job fires and dispatches to the private repo