### PR TITLE
chore(deps): consolidate Dependabot bumps (#150–#157)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,8 +6,8 @@ pypdf>=6.7.5  # PDF utilities - security patches (updated 2026-03-02)
 pandas>=2.2.0  # Data processing
 python-dotenv>=1.0.0  # Environment configuration
 tabulate>=0.9.0  # Table formatting
-cryptography>=46.0.5  # Cryptographic operations - security patches (updated 2026-03-02)
-openpyxl>=3.1.0  # Excel export (.xlsx format)
+cryptography>=47.0.0  # Cryptographic operations - security patches (updated 2026-04-29)
+openpyxl>=3.1.5  # Excel export (.xlsx format)
 
 # Note: Network libraries (requests, urllib3) intentionally excluded
 # This application processes sensitive financial data locally only

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 
 # Security scanning
 bandit==1.9.4
-pip-audit>=2.7.0
+pip-audit>=2.10.0
 
 # License compliance
 pip-licenses>=5.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ isort>=8.0.1,<9.0.0
 
 # Linting and Type Checking
 ruff>=0.15.12,<1.0.0
-mypy>=1.8.0,<2.0.0
+mypy>=1.20.2,<2.0.0
 pyright>=1.1.350
 
 # Type stubs (compatible versions)
@@ -29,6 +29,6 @@ pre-commit>=3.0.0,<5.0.0
 
 # Security tools (using compatible versions)
 bandit[toml]>=1.7.0,<2.0.0
-safety>=2.0.0,<4.0.0
-detect-secrets>=1.4.0,<2.0.0
-yamllint>=1.33.0,<2.0.0
+safety>=3.7.0,<4.0.0
+detect-secrets>=1.5.0,<2.0.0
+yamllint>=1.38.0,<2.0.0


### PR DESCRIPTION
## Summary

Consolidates 7 open Dependabot PRs into a single chore commit rather than merging them individually.

| Package | File | Old | New | Dependabot PR |
|---------|------|-----|-----|---------------|
| `cryptography` | `requirements/base.txt` | `>=46.0.5` | `>=47.0.0` | #152 |
| `openpyxl` | `requirements/base.txt` | `>=3.1.0` | `>=3.1.5` | #154 |
| `mypy` | `requirements/dev.txt` | `>=1.8.0,<2.0.0` | `>=1.20.2,<2.0.0` | #151 |
| `safety` | `requirements/dev.txt` | `>=2.0.0,<4.0.0` | `>=3.7.0,<4.0.0` | #156 |
| `detect-secrets` | `requirements/dev.txt` | `>=1.4.0,<2.0.0` | `>=1.5.0,<2.0.0` | #150 |
| `yamllint` | `requirements/dev.txt` | `>=1.33.0,<2.0.0` | `>=1.38.0,<2.0.0` | #157 |
| `pip-audit` | `requirements/ci.txt` | `>=2.7.0` | `>=2.10.0` | #155 |

All bumps are lower-bound increases within existing upper bounds — no breaking changes expected. The Dependabot PRs will be closed as superseded by this PR.

## Test plan

- [ ] CI passes (lint, security, tests)
- [ ] Close Dependabot PRs #150, #151, #152, #154, #155, #156, #157 as superseded