### PR TITLE
docs: update premium tier Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,29 @@ docker-compose up --build
 
 Place PDFs in `./input/` before running. Results are written to `./output/`.
 
-**Premium tier:** production Docker images are built and published from the private `bankstatements-premium` repository.
+**Premium tier:** production Docker images are published to the GitHub Container Registry.
+
+```bash
+docker pull ghcr.io/longieirl/bankstatements-premium:latest
+```
+
+To run:
+
+```bash
+docker run --rm \
+  --network none \
+  -v ./input:/app/input \
+  -v ./output:/app/output \
+  -v ./logs:/app/logs \
+  -v ./license.json:/app/license.json:ro \
+  -e LICENSE_PATH=/app/license.json \
+  -e OUTPUT_FORMATS=csv,json \
+  ghcr.io/longieirl/bankstatements-premium:latest
+```
+
+Place PDFs in `./input/`; results are written to `./output/`.
+
+> **License:** A `license.json` is only required for credit card statements. Without one, the processor will handle any statements containing an IBAN — credit card PDFs will be skipped.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `docker pull` and `docker run` example for the premium GHCR image
- Include volume mount flags (`input`, `output`, `logs`, `license.json`)
- Add license note: only required for credit card statements

## Changes
- Updated premium tier section in README.md

## Type
- [x] Documentation

## Testing
- [x] Manually tested
- [ ] Tests pass (coverage ≥ 91%)
- [ ] `make docker-integration` passed locally

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core`