### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/packages/parser-core/pyproject.toml
+++ b/packages/parser-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bankstatements-core"
-version = "0.1.3"
+version = "0.1.4"
 description = "Core PDF bank statement parsing library"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/parser-core/src/bankstatements_core/__version__.py
+++ b/packages/parser-core/src/bankstatements_core/__version__.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.3"
-__version_info__ = (0, 1, 3)
+__version__ = "0.1.4"
+__version_info__ = (0, 1, 4)

--- a/packages/parser-free/pyproject.toml
+++ b/packages/parser-free/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bankstatements-free"
-version = "0.1.3"
+version = "0.1.4"
 description = "Free-tier CLI for bankstatements-core PDF bank statement processor"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
# Pull Request

## Summary
Bumps all three version files from `0.1.3` to `0.1.4` ahead of the `core-v0.1.4` release tag. This release publishes the patched Docker image that fixes CVE-2026-31789 (merged in #163).

## Changes
- `packages/parser-core/pyproject.toml`: `0.1.3` → `0.1.4`
- `packages/parser-core/src/bankstatements_core/__version__.py`: `0.1.3` → `0.1.4`
- `packages/parser-free/pyproject.toml`: `0.1.3` → `0.1.4`

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [x] Security

## Testing
- [x] Tests pass (coverage >= 91%)
- [ ] Manually tested
- [ ] `make docker-integration` passed locally

No logic changes — version strings only.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core` (exported class, function, or exception)

After merge, cut tag `core-v0.1.4` — `release.yml` publishes on `core-v*` tags and will push the patched image to `:latest`.
