### PR TITLE
fix: update release workflow to monorepo package paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Verify version consistency
         run: |
           TAG_VERSION=${{ steps.get-version.outputs.version }}
-          CODE_VERSION=$(grep '__version__ = ' src/__version__.py | cut -d'"' -f2)
-          TOML_VERSION=$(grep 'version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          CODE_VERSION=$(grep '__version__ = ' packages/parser-core/src/bankstatements_core/__version__.py | cut -d'"' -f2)
+          TOML_VERSION=$(grep '^version = ' packages/parser-core/pyproject.toml | cut -d'"' -f2)
 
           echo "Tag version: ${TAG_VERSION}"
           echo "Code version: ${CODE_VERSION}"


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the `release.yml` workflow which was reading version files from the pre-monorepo repo root (`src/__version__.py`, `pyproject.toml`). Updates paths to the correct monorepo locations under `packages/parser-core/`. Also tightens the `grep` pattern from `version = ` to `^version = ` to avoid accidentally matching `target-version` in the ruff config section.

This was discovered when attempting to publish the `v0.1.4` Docker image to fix CVE-2026-31789 (#159) — the validate-version job failed with `src/__version__.py: No such file or directory`.

## Changes
- `.github/workflows/release.yml`: update `src/__version__.py` → `packages/parser-core/src/bankstatements_core/__version__.py`
- `.github/workflows/release.yml`: update `pyproject.toml` → `packages/parser-core/pyproject.toml` with anchored grep pattern

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Security

## Testing
- [x] Tests pass (coverage >= 91%)
- [ ] Manually tested
- [ ] `make docker-integration` passed locally

CI-only change — no Python source modified. The fix will be verified when `v0.1.4` is re-tagged after merge.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core` (exported class, function, or exception)

After merge: delete the failed `v0.1.4` tag, re-cut it, and the Release workflow will publish the patched Docker image for #159.
