### PR TITLE
fix(sec): harden remaining workflow shell injection points and urllib guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           docker run --rm \
-            bankstatementsprocessor:pr-${PR_NUMBER} \
+            "bankstatementsprocessor:pr-${PR_NUMBER}" \
             python -c "import bankstatements_free; import bankstatements_core; print('imports OK')"
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,9 +371,11 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Smoke-test image
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           docker run --rm \
-            bankstatementsprocessor:pr-${{ github.event.pull_request.number }} \
+            bankstatementsprocessor:pr-${PR_NUMBER} \
             python -c "import bankstatements_free; import bankstatements_core; print('imports OK')"
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
           echo "Version from tag: ${TAG_VERSION}"
 
       - name: Verify version consistency
+        env:
+          TAG_VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          TAG_VERSION=${{ steps.get-version.outputs.version }}
           CODE_VERSION=$(grep '__version__ = ' packages/parser-core/src/bankstatements_core/__version__.py | cut -d'"' -f2)
           TOML_VERSION=$(grep '^version = ' packages/parser-core/pyproject.toml | cut -d'"' -f2)
 
@@ -68,8 +69,10 @@ jobs:
 
       - name: Extract metadata
         id: meta
+        env:
+          RELEASE_VERSION: ${{ needs.validate-version.outputs.version }}
         run: |
-          VERSION=${{ needs.validate-version.outputs.version }}
+          VERSION="${RELEASE_VERSION}"
           MAJOR=$(echo ${VERSION} | cut -d. -f1)
           MINOR=$(echo ${VERSION} | cut -d. -f1-2)
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -103,9 +106,11 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Verify image
+        env:
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker pull ghcr.io/longieirl/bankstatements:${{ steps.meta.outputs.version }}
-          docker inspect ghcr.io/longieirl/bankstatements:${{ steps.meta.outputs.version }} | jq '.[0].Config.Labels'
+          docker pull ghcr.io/longieirl/bankstatements:${RELEASE_VERSION}
+          docker inspect ghcr.io/longieirl/bankstatements:${RELEASE_VERSION} | jq '.[0].Config.Labels'
 
       - name: Run Trivy vulnerability scanner on release
         uses: aquasecurity/trivy-action@master
@@ -141,8 +146,10 @@ jobs:
 
       - name: Extract changelog for version
         id: changelog
+        env:
+          RELEASE_VERSION: ${{ needs.validate-version.outputs.version }}
         run: |
-          VERSION=${{ needs.validate-version.outputs.version }}
+          VERSION="${RELEASE_VERSION}"
 
           # Extract changelog section for this version
           CHANGELOG=$(awk "/## \[${VERSION}\]/,/## \[/{if(/## \[${VERSION}\]/)p=1;else if(/## \[/)p=0;if(p)print}" CHANGELOG.md | tail -n +2)
@@ -167,16 +174,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release summary
+        env:
+          RELEASE_VERSION: ${{ needs.validate-version.outputs.version }}
         run: |
           {
-            echo "## 🚀 Release v${{ needs.validate-version.outputs.version }}"
+            echo "## 🚀 Release v${RELEASE_VERSION}"
             echo ""
             echo "### Docker Images"
-            echo "- \`ghcr.io/longieirl/bankstatements:${{ needs.validate-version.outputs.version }}\`"
+            echo "- \`ghcr.io/longieirl/bankstatements:${RELEASE_VERSION}\`"
             echo "- \`ghcr.io/longieirl/bankstatements:latest\`"
             echo ""
             echo "### Pull Command"
             echo "\`\`\`bash"
-            echo "docker pull ghcr.io/longieirl/bankstatements:${{ needs.validate-version.outputs.version }}"
+            echo "docker pull ghcr.io/longieirl/bankstatements:${RELEASE_VERSION}"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
           RELEASE_VERSION: ${{ needs.validate-version.outputs.version }}
         run: |
           VERSION="${RELEASE_VERSION}"
-          MAJOR=$(echo ${VERSION} | cut -d. -f1)
-          MINOR=$(echo ${VERSION} | cut -d. -f1-2)
+          MAJOR=$(echo "${VERSION}" | cut -d. -f1)
+          MINOR=$(echo "${VERSION}" | cut -d. -f1-2)
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           VCS_REF=$(git rev-parse --short HEAD)
 
@@ -109,8 +109,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker pull ghcr.io/longieirl/bankstatements:${RELEASE_VERSION}
-          docker inspect ghcr.io/longieirl/bankstatements:${RELEASE_VERSION} | jq '.[0].Config.Labels'
+          docker pull "ghcr.io/longieirl/bankstatements:${RELEASE_VERSION}"
+          docker inspect "ghcr.io/longieirl/bankstatements:${RELEASE_VERSION}" | jq '.[0].Config.Labels'
 
       - name: Run Trivy vulnerability scanner on release
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/thank-you-sync.yml
+++ b/.github/workflows/thank-you-sync.yml
@@ -19,7 +19,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # 1. Get all unique authors from the commits in this merged PR
-          COMMITTERS=$(gh pr view $PR_NUMBER --json commits --jq '.commits[].author.login' | sort -u)
+          COMMITTERS=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].author.login' | sort -u)
           # 2. Loop through each committer
           for USER in $COMMITTERS; do
             if [ "$USER" == "web-flow" ] || [ -z "$USER" ]; then continue; fi

--- a/.github/workflows/thank-you-sync.yml
+++ b/.github/workflows/thank-you-sync.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Add all committers if new
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # 1. Get all unique authors from the commits in this merged PR
-          PR_NUMBER=${{ github.event.pull_request.number }}
           COMMITTERS=$(gh pr view $PR_NUMBER --json commits --jq '.commits[].author.login' | sort -u)
           # 2. Loop through each committer
           for USER in $COMMITTERS; do
@@ -32,8 +32,10 @@ jobs:
             fi
           done
       - name: Commit and Push
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add THANKYOU.md
-          git diff --quiet --staged || (git commit -m "docs: add new contributors from PR #${{ github.event.pull_request.number }}" && git push)
+          git diff --quiet --staged || (git commit -m "docs: add new contributors from PR #${PR_NUMBER}" && git push)

--- a/scripts/supply_chain_risk.py
+++ b/scripts/supply_chain_risk.py
@@ -11,12 +11,15 @@ Usage:
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List
 import urllib.request
 import urllib.error
+
+_PYPI_NAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$")
 
 
 def load_sbom(path: Path) -> Dict[str, Any]:
@@ -54,6 +57,8 @@ def fetch_pypi_metadata(package_name: str) -> Dict[str, Any]:
 
     Returns empty dict if package not found or error occurs.
     """
+    if not _PYPI_NAME_RE.match(package_name):
+        return {}
     try:
         url = f"https://pypi.org/pypi/{package_name}/json"
         with urllib.request.urlopen(url, timeout=5) as response:


### PR DESCRIPTION
## Summary

Follow-on from #170. Independent code review of the shell injection fix identified three additional workflow files carrying the same `${{ github.* }}` / `${{ needs.*.outputs.* }}` interpolation-in-run pattern, plus a urllib input validation gap in `scripts/supply_chain_risk.py`.

Closes #168 (remaining gaps identified by independent review).
Closes #169 (urllib file:// vector hardened before script enters CI).

## Changes

### Workflow hardening (shell injection — same pattern as PR #170)

| File | Steps fixed | Prior risk |
|------|-------------|------------|
| `release.yml` | Verify version consistency, Extract metadata, Verify image, Extract changelog, Release summary | **High** — workflow has `contents: write` + `packages: write` permissions |
| `thank-you-sync.yml` | Add all committers, Commit and Push | Low — PR number is integer, but consistent with project posture |
| `ci.yml` | Smoke-test image | Low — PR number is integer |

All `${{ ... }}` expressions moved to `env:` blocks; `run:` scripts reference `${ENV_VAR}` only.

### `scripts/supply_chain_risk.py` — PyPI name validation guard

Added `_PYPI_NAME_RE` (PEP 508 package name regex) that rejects any `package_name` not matching `^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$` before the `urllib.request.urlopen` call. This eliminates any theoretical path-traversal or scheme-injection vector if this script is ever wired into CI with an untrusted SBOM as input.

## Type
- [x] Security

## Testing
- [x] Workflow-only changes verified by reading final file state
- [x] `supply_chain_risk.py` change is a pure guard — returns `{}` for invalid names, same as the existing error path; no behaviour change for valid PyPI names
- [ ] Tests pass (coverage ≥ 91%) — no Python package source changed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core`