### PR TITLE
chore(deps): consolidate dependabot lower-bound bumps (May 2026)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,10 +2,10 @@
 # Core dependencies for FREE and PAID tiers
 
 pdfplumber>=0.11.9  # PDF parsing (updated 2026-03-02)
-pypdf>=6.7.5  # PDF utilities - security patches (updated 2026-03-02)
+pypdf>=6.10.2  # PDF utilities - security patches (updated 2026-03-02)
 pandas>=2.2.0  # Data processing
-python-dotenv>=1.0.0  # Environment configuration
-tabulate>=0.9.0  # Table formatting
+python-dotenv>=1.2.2  # Environment configuration
+tabulate>=0.10.0  # Table formatting
 cryptography>=47.0.0  # Cryptographic operations - security patches (updated 2026-04-29)
 openpyxl>=3.1.5  # Excel export (.xlsx format)
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ pip-audit>=2.10.0
 pip-licenses>=5.0.0
 
 # SBOM and drift detection
-PyYAML>=6.0
+PyYAML>=6.0.3
 
 # Complexity analysis
-xenon>=0.9.0
+xenon>=0.9.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,13 +5,13 @@
 -r base.txt
 
 # Code formatting
-black>=23.0.0,<27.0.0
+black>=26.3.1,<27.0.0
 isort>=8.0.1,<9.0.0
 
 # Linting and Type Checking
 ruff>=0.15.12,<1.0.0
 mypy>=1.20.2,<2.0.0
-pyright>=1.1.350
+pyright>=1.1.409
 
 # Type stubs (compatible versions)
 types-python-dateutil>=2.8.0.0
@@ -21,11 +21,11 @@ types-tabulate>=0.10.0.20260408
 # Note: types-requests removed (requests library not used for GDPR compliance)
 
 # Development and debugging tools
-ipython>=8.0.0,<10.0.0
-ipdb>=0.13.0
+ipython>=9.13.0,<10.0.0
+ipdb>=0.13.13
 
 # Pre-commit hooks
-pre-commit>=3.0.0,<5.0.0
+pre-commit>=4.6.0,<5.0.0
 
 # Security tools (using compatible versions)
 bandit[toml]>=1.7.0,<2.0.0


### PR DESCRIPTION
## Summary

Consolidates 10 individual Dependabot PRs (#173–#182) into a single clean commit. All PRs were green (CI Pass ✅) before consolidation; changes are lower-bound tightening only — no breaking version changes.

### Changes

| File | Dependency | From | To |
|---|---|---|---|
| `requirements/base.txt` | `pypdf` | `>=6.7.5` | `>=6.10.2` |
| `requirements/base.txt` | `python-dotenv` | `>=1.0.0` | `>=1.2.2` |
| `requirements/base.txt` | `tabulate` | `>=0.9.0` | `>=0.10.0` |
| `requirements/dev.txt` | `black` | `>=23.0.0,<27.0.0` | `>=26.3.1,<27.0.0` |
| `requirements/dev.txt` | `pyright` | `>=1.1.350` | `>=1.1.409` |
| `requirements/dev.txt` | `ipython` | `>=8.0.0,<10.0.0` | `>=9.13.0,<10.0.0` |
| `requirements/dev.txt` | `ipdb` | `>=0.13.0` | `>=0.13.13` |
| `requirements/dev.txt` | `pre-commit` | `>=3.0.0,<5.0.0` | `>=4.6.0,<5.0.0` |
| `requirements/ci.txt` | `PyYAML` | `>=6.0` | `>=6.0.3` |
| `requirements/ci.txt` | `xenon` | `>=0.9.0` | `>=0.9.3` |

### Closes

#173 #174 #175 #176 #177 #178 #179 #180 #181 #182

## Test plan

- [ ] CI passes on this PR (lint, tests, security, Docker)
- [ ] After merge, close the 10 individual Dependabot PRs as superseded