### PR TITLE
chore: wire git hooks setup into Makefile and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,9 @@ pip install -e "packages/parser-core[dev,test]"
 
 # Install parser-free in editable mode (depends on parser-core above)
 pip install -e "packages/parser-free[test]"
+
+# Activate local git hooks (blocks direct pushes to main)
+git config core.hooksPath .githooks
 ```
 
 ### Verify Setup

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ setup:	## Full development environment setup
 	$(MAKE) pre-commit-install
 	chmod +x setup-git-hooks.sh
 	./setup-git-hooks.sh
+	git config core.hooksPath .githooks
 	@echo "✅ Setup complete!"
 
 # Testing


### PR DESCRIPTION
# Pull Request

## Summary
Ensures new clones automatically activate the `.githooks/pre-push` hook that blocks direct pushes to `main`. Previously `git config core.hooksPath .githooks` was a manual step with no documentation.

## Changes
- `Makefile` — `make setup` now runs `git config core.hooksPath .githooks`
- `CONTRIBUTING.md` — local setup steps include the `git config` command with a note explaining what it does

## Type
- [x] Documentation

## Testing
- [x] Manually tested

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Documentation updated (if needed)
- [x] No new warnings

## Downstream impact
- [ ] This PR changes a public interface in `bankstatements_core` (exported class, function, or exception)