### PR TITLE
feat: add taste-skill style plugin structure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "bankstatements-skills",
+  "description": "Bank statement processing skills for Claude Code",
+  "owner": {
+    "name": "longieirl",
+    "email": ""
+  },
+  "plugins": [
+    {
+      "name": "bankstatements-skills",
+      "description": "Claude Code skills for processing PDF bank statements — extract transactions, generate CSV/Excel/JSON output",
+      "version": "1.0.0",
+      "source": "./",
+      "author": {
+        "name": "longieirl",
+        "email": ""
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "bankstatements-skills",
+  "description": "Claude Code skills for processing PDF bank statements — extract transactions, generate CSV/Excel/JSON output",
+  "version": "1.0.0",
+  "author": {
+    "name": "longieirl",
+    "email": ""
+  },
+  "homepage": "https://github.com/longieirl/bankstatementprocessor",
+  "repository": "https://github.com/longieirl/bankstatementprocessor",
+  "license": "MIT",
+  "keywords": ["skills", "bank-statements", "pdf", "csv", "excel", "finance", "transactions"]
+}

--- a/skill.sh
+++ b/skill.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Skill registry — maps skill names to their SKILL.md paths.
+# Usage: source ./skill.sh <skill-name>
+
+declare -A SKILLS=(
+  ["process-bank-statements"]="skills/process-bank-statements/SKILL.md"
+)
+
+if [ $# -eq 0 ]; then
+  echo "Usage: source ./skill.sh <skill-name>"
+  echo ""
+  echo "Available skills:"
+  for key in "${!SKILLS[@]}"; do
+    echo "  - $key  →  ${SKILLS[$key]}"
+  done
+  exit 0
+fi
+
+path="${SKILLS[$1]}"
+
+if [ -z "$path" ]; then
+  echo "Unknown skill: $1"
+  echo "Run ./skill.sh with no arguments to list available skills."
+  exit 1
+fi
+
+echo "$path"

--- a/skills/llms.txt
+++ b/skills/llms.txt
@@ -1,0 +1,7 @@
+# Bank Statement Processor — Skills Registry
+
+> Claude Code skills for processing PDF bank statements. Each skill guides an AI agent through install checking, input gathering, CLI invocation, and output review.
+
+## Skills
+
+- [process-bank-statements](process-bank-statements/SKILL.md): Extract transactions from PDF bank statements to CSV, Excel, or JSON using the `bankstatements` CLI


### PR DESCRIPTION
## Summary

Mirrors the [taste-skill](https://github.com/Leonxlnx/taste-skill) repo structure so the project follows the same portable, discoverable agent skills convention.

- `.claude-plugin/plugin.json` — Claude plugin metadata (name, version, author, keywords)
- `.claude-plugin/marketplace.json` — marketplace registration config
- `skill.sh` — bash registry: `./skill.sh process-bank-statements` returns the path to the skill file
- `skills/llms.txt` — skills-specific LLM index (separate from root `llms.txt`)

## Repo structure now matches taste-skill

```
skills/
  llms.txt
  process-bank-statements/
    SKILL.md
.claude-plugin/
  plugin.json
  marketplace.json
skill.sh
llms.txt
```

## Test plan

- [ ] `./skill.sh` lists available skills
- [ ] `./skill.sh process-bank-statements` returns `skills/process-bank-statements/SKILL.md`
- [ ] `./skill.sh unknown-skill` exits with error message