### PR TITLE
chore: repo governance, CI security hardening, branch protection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,23 @@
+name: Auto-assign PR creator
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.actor]
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,31 @@ jobs:
             python -c "import bankstatements_free; import bankstatements_core; print('imports OK')"
 
   # ---------------------------------------------------------------------------
+  # Security lint — secrets scan (gitleaks) + YAML lint (yamllint).
+  # Runs on every PR and push regardless of which paths changed.
+  # ---------------------------------------------------------------------------
+  security-lint:
+    name: Security lint — gitleaks + yamllint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Secrets scan
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: YAML lint
+        run: |
+          pip install yamllint --quiet
+          yamllint -c .yamllint.yml .
+
+  # ---------------------------------------------------------------------------
   # Workflow lint — validates GitHub Actions YAML syntax on PRs.
   # ---------------------------------------------------------------------------
   workflow-lint:
@@ -450,7 +475,7 @@ jobs:
     name: CI Pass
     runs-on: ubuntu-latest
     if: always()
-    needs: [changes, lint-core, lint-free, security, test-core, test-free, build-docker, workflow-lint, check-test-structure]
+    needs: [changes, lint-core, lint-free, security, test-core, test-free, build-docker, workflow-lint, check-test-structure, security-lint]
     steps:
       - name: Check all jobs passed
         run: |

--- a/.github/workflows/docker-advisory.yml
+++ b/.github/workflows/docker-advisory.yml
@@ -1,0 +1,51 @@
+name: Docker security advisory
+
+on:
+  pull_request:
+    paths:
+      - '**/Dockerfile*'
+      - '**/docker-compose*.yml'
+      - '**/docker-compose*.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  advisory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Scan for risky Docker patterns
+        run: |
+          patterns=(
+            "privileged: true"
+            "network_mode: host"
+            "/var/run/docker.sock"
+            "cap_add"
+            "SYS_ADMIN"
+            "user: root"
+            "0\.0\.0\.0:"
+          )
+
+          {
+            echo "## Docker Security Advisory"
+            echo ""
+
+            found=0
+            for pattern in "${patterns[@]}"; do
+              matches=$(find . \( -name "Dockerfile*" -o -name "docker-compose*.yml" -o -name "docker-compose*.yaml" \) \
+                -exec grep -nH "$pattern" {} + 2>/dev/null || true)
+              if [ -n "$matches" ]; then
+                echo "**Pattern:** \`$pattern\`"
+                echo '```'
+                echo "$matches"
+                echo '```'
+                found=$((found + 1))
+              fi
+            done
+
+            if [ "$found" -eq 0 ]; then
+              echo "No risky patterns found."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,27 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 3 * * 1'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186  # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,26 @@
+extends: default
+rules:
+  document-start: disable
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 1
+  line-length:
+    max: 200
+    level: warning
+  comments:
+    min-spaces-from-content: 1
+  truthy:
+    check-keys: false  # permits `on:` in GitHub Actions files
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  indentation:
+    spaces: 2
+    indent-sequences: whatever
+    check-multi-line-strings: false
+  new-line-at-end-of-file: disable
+ignore: |
+  .git
+  node_modules
+  .claude

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Scope
+
+This policy covers the `longieirl/bankstatementprocessor` repository.
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/longieirl/bankstatementprocessor/security/advisories/new).
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions or files
+- Potential impact
+
+Do not open a public issue for security vulnerabilities.
+
+**Expected response:** acknowledgement within 7 days, resolution timeline within 30 days.
+
+## Push protection bypass policy
+
+Secret scanning push protection can be bypassed by users with write access. This is not permitted unless the detected secret is a confirmed false positive. Any bypass must be reviewed by the repository owner. Bypass events are logged in the repository audit log.
+
+## Known accepted risks
+
+<!-- Document accepted patterns here so reviewers do not re-flag them. -->
+<!-- Example: Docker socket mount required for Watchtower; NET_ADMIN required for WireGuard -->


### PR DESCRIPTION
## Summary

Full lockdown per `github-repo-lockdown` skill:
- Branch ruleset with PR-required flow, CODEOWNER review enforcement, dismiss stale reviews, last-push approval, and thread resolution. Admin bypass mode is `pull_request` (no solo-owner deadlock).
- SECURITY.md with vulnerability reporting policy and push protection bypass policy.
- `.gitattributes` for cross-platform line ending normalisation.
- `.yamllint.yml` calibrated against existing tree (passes clean with `indent-sequences: whatever` to allow mixed GitHub Actions / pre-commit styles).
- `security-lint` CI job in `ci.yml`: gitleaks secrets scan + yamllint on every PR. Added to `ci-pass` aggregate gate.
- `auto-assign.yml`: auto-assigns PR creator (skips bot actors to avoid GitHub 422).
- `scorecard.yml`: OpenSSF Scorecard weekly + on push to main, publishes SARIF to Security tab.
- `docker-advisory.yml`: advisory scan for risky Docker patterns on Dockerfile/compose changes (exits 0, documents findings in step summary).

## Area affected

`.github/workflows/`, `SECURITY.md`, `.gitattributes`, `.yamllint.yml`

## Security impact

Branch ruleset is the main change. All new workflow action refs are pinned by commit SHA. No `${{ github.event.* }}` interpolated directly into `run:` blocks.

## Tested locally

- `actionlint .github/workflows/*.yml` — clean
- `yamllint -c .yamllint.yml .` — clean
- Branch ruleset verified: direct push to main rejected (GH013)

## Checklist

- [x] No secrets, credentials, or personal environment paths included
- [x] Local validation passes
- [x] One logical change per PR