### PR TITLE
chore: ignore CVE-2026-42496 (perl-base fix_deferred), refresh .trivyignore review dates

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -8,6 +8,13 @@
 # Re-evaluate when a Debian patch is released.
 CVE-2026-33845
 
-# Last review: 2026-05-08
-# Next review: 2026-06-08
+# CVE-2026-42496: perl-base / perl-archive-tar — path traversal when extracting
+# tar archives. fix_deferred upstream; no Debian patch available as of 2026-07-30.
+# This application never extracts tar archives — perl is an indirect OS dependency
+# (poppler-utils) with no user-controlled archive extraction path.
+# Re-evaluate when a Debian patch is released.
+CVE-2026-42496
+
+# Last review: 2026-07-30
+# Next review: 2026-08-30
 


### PR DESCRIPTION
## Summary

- Adds `CVE-2026-42496` to `.trivyignore` — `perl-base`/`perl-archive-tar` path traversal, upstream fix deferred, no Debian patch available as of 2026-07-30. Application never extracts tar archives; perl is an indirect OS dependency only.
- Updates review dates from 2026-05-08 to 2026-07-30 (next review 2026-08-30).
- `CVE-2026-42010` (libgnutls30t64 auth bypass) is **not** ignored — it has a fix available (`3.8.9-3+deb13u4`) and will be resolved automatically by `apt-get upgrade -y` on the next image rebuild.

Closes #219

## Test plan

- [ ] CI passes (Trivy scan no longer blocks on CVE-2026-42496)
- [ ] CVE-2026-42010 resolved by fresh image build via `apt-get upgrade -y`